### PR TITLE
chore: define .ico files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 *.jpg   binary
 *.png   binary
 *.gif   binary
+*.ico   binary
 
 # JS generated files
 yarn.lock linguist-generated=true


### PR DESCRIPTION
Hi @Cromeror, @paangaflo and @maurocardinali, this is to avoid the issue with the .ico file