### PR TITLE
DE-252 - Generate semantic version numbers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
             changeRequest target: 'main'
           }
           steps {
-            sh 'sh ./build-n-publish.sh pr-${CHANGE_ID}_${BUILD_NUMBER} https://cdn.fromdoppler.com'
+            sh 'sh ./build-n-publish.sh pr-${CHANGE_ID}_${BUILD_NUMBER}'
           }
         }
         stage('Publish pre-release images from main') {
@@ -47,7 +47,7 @@ pipeline {
             branch 'main'
           }
           steps {
-            sh 'sh build-n-publish.sh main-${BUILD_NUMBER} https://cdn.fromdoppler.com'
+            sh 'sh build-n-publish.sh main-${BUILD_NUMBER}'
           }
         }
         stage('Publish final version images') {
@@ -57,7 +57,7 @@ pipeline {
             }
           }
           steps {
-            sh 'sh build-n-publish.sh ${TAG_NAME} https://cdn.fromdoppler.com'
+            sh 'sh build-n-publish.sh ${TAG_NAME}'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
             changeRequest target: 'main'
           }
           steps {
-            sh 'sh ./build-n-publish.sh --name=pr-${CHANGE_ID}_${BUILD_NUMBER}'
+            sh 'sh ./build-n-publish.sh --commit=${GIT_COMMIT} --name=pr-${CHANGE_ID}'
           }
         }
         stage('Publish pre-release images from main') {
@@ -47,7 +47,7 @@ pipeline {
             branch 'main'
           }
           steps {
-            sh 'sh build-n-publish.sh --name=main-${BUILD_NUMBER}'
+            sh 'sh build-n-publish.sh --commit=${GIT_COMMIT} --name=main-${BUILD_NUMBER}'
           }
         }
         stage('Publish final version images') {
@@ -57,7 +57,7 @@ pipeline {
             }
           }
           steps {
-            sh 'sh build-n-publish.sh --version=${TAG_NAME}'
+            sh 'sh build-n-publish.sh --commit=${GIT_COMMIT} --version=${TAG_NAME}'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,14 @@ pipeline {
             sh 'sh build-n-publish.sh --commit=${GIT_COMMIT} --name=main-${BUILD_NUMBER}'
           }
         }
+        stage('Publish pre-release images from INT') {
+          when {
+            branch 'INT'
+          }
+          steps {
+            sh 'sh build-n-publish.sh --commit=${GIT_COMMIT} --name=INT-${BUILD_NUMBER}'
+          }
+        }
         stage('Publish final version images') {
           when {
             expression {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
             changeRequest target: 'main'
           }
           steps {
-            sh 'sh ./build-n-publish.sh pr-${CHANGE_ID}_${BUILD_NUMBER}'
+            sh 'sh ./build-n-publish.sh --version=pr-${CHANGE_ID}_${BUILD_NUMBER}'
           }
         }
         stage('Publish pre-release images from main') {
@@ -47,7 +47,7 @@ pipeline {
             branch 'main'
           }
           steps {
-            sh 'sh build-n-publish.sh main-${BUILD_NUMBER}'
+            sh 'sh build-n-publish.sh --version=main-${BUILD_NUMBER}'
           }
         }
         stage('Publish final version images') {
@@ -57,7 +57,7 @@ pipeline {
             }
           }
           steps {
-            sh 'sh build-n-publish.sh ${TAG_NAME}'
+            sh 'sh build-n-publish.sh --version=${TAG_NAME}'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
             changeRequest target: 'main'
           }
           steps {
-            sh 'sh ./build-n-publish.sh --version=pr-${CHANGE_ID}_${BUILD_NUMBER}'
+            sh 'sh ./build-n-publish.sh --name=pr-${CHANGE_ID}_${BUILD_NUMBER}'
           }
         }
         stage('Publish pre-release images from main') {
@@ -47,7 +47,7 @@ pipeline {
             branch 'main'
           }
           steps {
-            sh 'sh build-n-publish.sh --version=main-${BUILD_NUMBER}'
+            sh 'sh build-n-publish.sh --name=main-${BUILD_NUMBER}'
           }
         }
         stage('Publish final version images') {

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -5,6 +5,7 @@ pkgName="unlayer-editor"
 cdnBaseUrl="https://cdn.fromdoppler.com"
 
 # parameters
+name=""
 version=""
 
 print_help () {
@@ -14,16 +15,22 @@ print_help () {
     echo "Use Docker to build project's bundle files and publish them to our CDN"
     echo ""
     echo "Options:"
-    echo "  -v, --version, version number (mandatory)"
+    echo "  -n, --name, version name"
+    echo "  -v, --version, version number"
     echo "  -h, --help"
+    echo "Only one of name or version parameters is required, and cannot be included together."
     echo
     echo "Examples:"
     echo "  sh build-n-publish.sh --version=v1.2.11"
     echo "  sh build-n-publish.sh -v=v1.2.11"
+    echo "  sh build-n-publish.sh --name=main"
 }
 
 for i in "$@" ; do
 case $i in
+    -n=*|--name=*)
+    name="${i#*=}"
+    ;;
     -v=*|--version=*)
     version="${i#*=}"
     ;;
@@ -34,9 +41,17 @@ case $i in
 esac
 done
 
-if [ -z "${version}" ]
+
+if [ -n "${version}" ] && [ -n "${name}" ]
 then
-  echo "Error: version parameter is mandatory"
+  echo "Error: name and version parameters cannot be included together"
+  print_help
+  exit 1
+fi
+
+if [ -z "${version}" ] && [ -z "${name}" ]
+then
+  echo "Error: one of name or version parameters is required"
   print_help
   exit 1
 fi
@@ -56,7 +71,16 @@ cd "$(dirname "$0")"
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL="*"
 
-tag="${pkgName}-${version}-$(date +%Y%m%d%H%M%S)"
+# TODO: parse version or name into components
+if [ -n "${version}" ]
+then
+  tag="${pkgName}-${version}-$(date +%Y%m%d%H%M%S)"
+fi
+
+if [ -n "${name}" ]
+then
+  tag="${pkgName}-${name}-$(date +%Y%m%d%H%M%S)"
+fi
 
 docker build . \
   --build-arg baseUrl="${cdnBaseUrl}" \

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -2,7 +2,7 @@
 
 # constants
 pkgName="unlayer-editor"
-cdnBaseUrl="https//cdn.fromdoppler.com"
+cdnBaseUrl="https://cdn.fromdoppler.com"
 
 # parameters
 pkgVersion=${1:-"v0.0.0-build0"}

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -5,7 +5,41 @@ pkgName="unlayer-editor"
 cdnBaseUrl="https://cdn.fromdoppler.com"
 
 # parameters
-version=${1:?}
+version=""
+
+print_help () {
+    echo ""
+    echo "Usage: sh build-n-publish.sh [OPTIONS]"
+    echo ""
+    echo "Use Docker to build project's bundle files and publish them to our CDN"
+    echo ""
+    echo "Options:"
+    echo "  -v, --version, version number (mandatory)"
+    echo "  -h, --help"
+    echo
+    echo "Examples:"
+    echo "  sh build-n-publish.sh --version=v1.2.11"
+    echo "  sh build-n-publish.sh -v=v1.2.11"
+}
+
+for i in "$@" ; do
+case $i in
+    -v=*|--version=*)
+    version="${i#*=}"
+    ;;
+    -h|--help)
+    print_help
+    exit 0
+    ;;
+esac
+done
+
+if [ -z "${version}" ]
+then
+  echo "Error: version parameter is mandatory"
+  print_help
+  exit 1
+fi
 
 # Stop script on NZEC
 set -e

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -4,12 +4,20 @@ pkgName="unlayer-editor"
 pkgVersion=${1:-"v0.0.0-build0"}
 cdnBaseUrl=${2:-"https//cdn.fromdoppler.com"}
 
-# Exit immediately if a command exits with a non-zero status.
+# Stop script on NZEC
 set -e
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
 
 # Lines added to get the script running in the script path shell context
 # reference: http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
 cd "$(dirname "$0")"
+
+# To avoid issues with MINGW and Git Bash, see:
+# https://github.com/docker/toolbox/issues/673
+# https://gist.github.com/borekb/cb1536a3685ca6fc0ad9a028e6a959e3
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL="*"
 
 tag="${pkgName}-${pkgVersion}-$(date +%Y%m%d%H%M%S)"
 

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -5,7 +5,7 @@ pkgName="unlayer-editor"
 cdnBaseUrl="https://cdn.fromdoppler.com"
 
 # parameters
-pkgVersion=${1:-"v0.0.0-build0"}
+version=${1:?}
 
 # Stop script on NZEC
 set -e
@@ -22,12 +22,12 @@ cd "$(dirname "$0")"
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL="*"
 
-tag="${pkgName}-${pkgVersion}-$(date +%Y%m%d%H%M%S)"
+tag="${pkgName}-${version}-$(date +%Y%m%d%H%M%S)"
 
 docker build . \
   --build-arg baseUrl="${cdnBaseUrl}" \
   --build-arg pkgName="${pkgName}" \
-  --build-arg version="${pkgVersion}" \
+  --build-arg version="${version}" \
   --tag "${tag}"
 
 docker run --rm \
@@ -36,4 +36,4 @@ docker run --rm \
   /bin/sh -c "\
     scp -P \"${CDN_SFTP_PORT}\" -r \"/source/${pkgName}\" \"${CDN_SFTP_USERNAME}@${CDN_SFTP_HOSTNAME}:/${CDN_SFTP_BASE}/\""
 
-echo "Files ready in ${cdnBaseUrl}/${pkgName}/${pkgVersion}"
+echo "Files ready in ${cdnBaseUrl}/${pkgName}/${version}"

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
+# constants
 pkgName="unlayer-editor"
+cdnBaseUrl="https//cdn.fromdoppler.com"
+
+# parameters
 pkgVersion=${1:-"v0.0.0-build0"}
-cdnBaseUrl=${2:-"https//cdn.fromdoppler.com"}
 
 # Stop script on NZEC
 set -e

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -99,29 +99,109 @@ cd "$(dirname "$0")"
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL="*"
 
-# TODO: parse version or name into components
 if [ -n "${version}" ]
 then
-  tag="${pkgName}-${version}-$(date +%Y%m%d%H%M%S)"
+  versionBuild=${commit}
+  # Ugly code to deal with versions
+  # Input:
+  #   version=v12.34.5
+  #   versionBuild=94f85efb9c
+  #   versionPre=0pr
+  # Output:
+  #   versionMayor=pre-v12
+  #   versionMayorMinor=pre-v12.34
+  #   versionMayorMinorPatch=pre-v12.34.5
+  #   versionMayorMinorPatchPre=pre-v12.34.5-0pr
+  #   versionFull=pre-v12.34.5-0pr+94f85efb9c
+  #   versionFullForTag=pre-v12.34.5-0pr_94f85efb9c
+  # region Ugly code to deal with versions
+
+  versionFull=${version}
+
+  if [ -n "${versionPre}" ]
+  then
+    versionFull=${versionFull}-${versionPre}
+  fi
+
+  if [ -n "${versionBuild}" ]
+  then
+    versionFull=${versionFull}+${versionBuild}
+  fi
+
+  # https://semver.org/spec/v2.0.0.html#backusnaur-form-grammar-for-valid-semver-versions
+  # <valid semver> ::= <version core>
+  #                  | <version core> "-" <pre-release>
+  #                  | <version core> "+" <build>
+  #                  | <version core> "-" <pre-release> "+" <build>
+  #
+  # <version core> ::= <major> "." <minor> "." <patch>
+  versionBuild="$(echo "${versionFull}"+ | cut -d'+' -f2)"
+  versionMayorMinorPatchPre="$(echo "${versionFull}" | cut -d'+' -f1)" # v0.0.0-xxx (ignoring `+` if exists)
+  versionPre="$(echo "${versionMayorMinorPatchPre}"- | cut -d'-' -f2)"
+  versionMayorMinorPatch="$(echo "${versionMayorMinorPatchPre}" | cut -d'-' -f1)" # v0.0.0 (ignoring `-` if exists)
+  versionMayor="$(echo "${versionMayorMinorPatch}" | cut -d'.' -f1)" # v0
+  versionMinor="$(echo "${versionMayorMinorPatch}" | cut -d'.' -f2)"
+  versionMayorMinor="${versionMayor}.${versionMinor}" # v0.0
+  # by the moment we do not need it, versionPatch only for demo purposes
+  # versionPatch="$(echo "${versionMayorMinorPatch}" | cut -d'.' -f3)"
+
+  if [ -z "${versionBuild}" ]
+  then
+    canonicalTag=${versionMayorMinorPatchPre}
+  else
+    # because `+` is not accepted in tag names
+    canonicalTag=${versionMayorMinorPatchPre}_${versionBuild}
+  fi
+
+  if [ -n "${versionPre}" ]
+  then
+    preReleasePrefix="pre-"
+    versionMayor=${preReleasePrefix}${versionMayor}
+    versionMayorMinor=${preReleasePrefix}${versionMayorMinor}
+    versionMayorMinorPatch=${preReleasePrefix}${versionMayorMinorPatch}
+    versionMayorMinorPatchPre=${preReleasePrefix}${versionMayorMinorPatchPre}
+    versionFull=${preReleasePrefix}${versionFull}
+    canonicalTag=${preReleasePrefix}${canonicalTag}
+  fi
+  # endregion Ugly code to deal with versions
 fi
 
 if [ -n "${name}" ]
 then
-  tag="${pkgName}-${name}-$(date +%Y%m%d%H%M%S)"
+  versionFull=${name}-${commit}
+  canonicalTag=${versionFull}
 fi
-
-# TODO: use commit and pre-version-suffix
 
 docker build . \
   --build-arg baseUrl="${cdnBaseUrl}" \
   --build-arg pkgName="${pkgName}" \
-  --build-arg version="${version}" \
-  --tag "${tag}"
+  --build-arg version="${canonicalTag}" \
+  --tag "${canonicalTag}"
 
+# TODO: update this
+# BEGIN - Old behavior
 docker run --rm \
   -v /var/lib/jenkins/.ssh:/root/.ssh:ro \
-  "${tag}" \
+  "${canonicalTag}" \
   /bin/sh -c "\
     scp -P \"${CDN_SFTP_PORT}\" -r \"/source/${pkgName}\" \"${CDN_SFTP_USERNAME}@${CDN_SFTP_HOSTNAME}:/${CDN_SFTP_BASE}/\""
 
-echo "Files ready in ${cdnBaseUrl}/${pkgName}/${version}"
+echo "Files ready in ${cdnBaseUrl}/${pkgName}/${canonicalTag}"
+# END - Old behavior
+
+# TODO: Implement this:
+# BEGIN - Desired Behavior
+echo "We should generate ${cdnBaseUrl}/${pkgName}/asset-manifest-${canonicalTag}.json"
+if [ -n "${version}" ]
+then
+  echo "We should generate ${cdnBaseUrl}/${pkgName}/asset-manifest-${versionMayor}.json"
+  echo "We should generate ${cdnBaseUrl}/${pkgName}/asset-manifest-${versionMayorMinor}.json"
+  echo "We should generate ${cdnBaseUrl}/${pkgName}/asset-manifest-${versionMayorMinorPatch}.json"
+  echo "We should generate ${cdnBaseUrl}/${pkgName}/asset-manifest-${versionMayorMinorPatchPre}.json"
+fi
+
+if [ -n "${name}" ]
+then
+  echo "We should generate ${cdnBaseUrl}/${pkgName}/asset-manifest-${name}.json"
+fi
+# END - Desired Behavior


### PR DESCRIPTION
Hi team, this PR is split into some logical steps on each commit.

I think that the final behavior can be easily understood by reading the last part of  `build-n-publish.sh`.

Could you kindly review it?

---

## Final version

* git tag: `v12.34.5`
* commit: 2f2ed2d74a43475442fdca142fc8e6696d6a979b

Generated files (not yet):

* `https://cdn.fromdoppler.com/unlayer-editor/asset-manifest-v12.json`
* `https://cdn.fromdoppler.com/unlayer-editor/asset-manifest-v12.34.json`
* `https://cdn.fromdoppler.com/unlayer-editor/asset-manifest-v12.34.5.json`
* `https://cdn.fromdoppler.com/unlayer-editor/asset-manifest-v12.34.5_2f2ed2d74a43475442fdca142fc8e6696d6a979b.json`

## Pull request

* PR #5
* commit: 2f2ed2d74a43475442fdca142fc8e6696d6a979b

Generated files (not yet):

* `https://cdn.fromdoppler.com/unlayer-editor/asset-manifest-pr-5.json`
* `https://cdn.fromdoppler.com/unlayer-editor/asset-manifest-pr-5-2f2ed2d74a43475442fdca142fc8e6696d6a979b.json`