### PR TITLE
DE-258- Upload semantic version friendly manifests to CDN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM koalaman/shellcheck-alpine as verify-sh
 WORKDIR /src
 COPY ./*.sh ./
+COPY ./**/*.sh ./
 RUN shellcheck -e SC1091,SC1090 ./*.sh
 
 FROM node:14.17.4 AS restore
@@ -21,6 +22,6 @@ RUN yarn build
 
 # Using specific digest (f7f7607...) to avoid unwanted changes in the non-oficial image
 FROM ttionya/openssh-client@sha256:f7f7607d56f09a7c42e246e9c256ff51cf2f0802e3b2d88da6537bea516fe142 as final
-ARG pkgName=unlayer-editor
-ARG version=v0.0.0-build0
-COPY --from=build /src/build "/source/${pkgName}/${version}"
+WORKDIR /work
+COPY ./cdn-helpers/* ./
+COPY --from=build /src/build ./build/

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -111,5 +111,7 @@ docker run --rm \
       --name=\"${name}\" \
       --version=\"${version}\" \
       --pre-version-suffix=\"${versionPre}\" \
-    && scp -P \"${CDN_SFTP_PORT}\" -r \"/work/build/.\" \"${CDN_SFTP_USERNAME}@${CDN_SFTP_HOSTNAME}:/${CDN_SFTP_BASE}/${pkgName}/${tag}/\""
-# TODO: use the prepared files (/work/ready) in place of build ones (/work/build) in SCP
+    && sh ./upload.sh \
+      --port=\"${CDN_SFTP_PORT}\" \
+      --destination=\"${CDN_SFTP_USERNAME}@${CDN_SFTP_HOSTNAME}:/${CDN_SFTP_BASE}/${pkgName}/\" \
+    "

--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -2,7 +2,6 @@
 
 # constants
 pkgName="unlayer-editor"
-cdnBaseUrl="https://cdn.fromdoppler.com"
 
 # parameters
 commit=""
@@ -99,109 +98,18 @@ cd "$(dirname "$0")"
 export MSYS_NO_PATHCONV=1
 export MSYS2_ARG_CONV_EXCL="*"
 
-if [ -n "${version}" ]
-then
-  versionBuild=${commit}
-  # Ugly code to deal with versions
-  # Input:
-  #   version=v12.34.5
-  #   versionBuild=94f85efb9c
-  #   versionPre=0pr
-  # Output:
-  #   versionMayor=pre-v12
-  #   versionMayorMinor=pre-v12.34
-  #   versionMayorMinorPatch=pre-v12.34.5
-  #   versionMayorMinorPatchPre=pre-v12.34.5-0pr
-  #   versionFull=pre-v12.34.5-0pr+94f85efb9c
-  #   versionFullForTag=pre-v12.34.5-0pr_94f85efb9c
-  # region Ugly code to deal with versions
+tag="${pkgName}-${commit}"
 
-  versionFull=${version}
+docker build . --tag "${tag}"
 
-  if [ -n "${versionPre}" ]
-  then
-    versionFull=${versionFull}-${versionPre}
-  fi
-
-  if [ -n "${versionBuild}" ]
-  then
-    versionFull=${versionFull}+${versionBuild}
-  fi
-
-  # https://semver.org/spec/v2.0.0.html#backusnaur-form-grammar-for-valid-semver-versions
-  # <valid semver> ::= <version core>
-  #                  | <version core> "-" <pre-release>
-  #                  | <version core> "+" <build>
-  #                  | <version core> "-" <pre-release> "+" <build>
-  #
-  # <version core> ::= <major> "." <minor> "." <patch>
-  versionBuild="$(echo "${versionFull}"+ | cut -d'+' -f2)"
-  versionMayorMinorPatchPre="$(echo "${versionFull}" | cut -d'+' -f1)" # v0.0.0-xxx (ignoring `+` if exists)
-  versionPre="$(echo "${versionMayorMinorPatchPre}"- | cut -d'-' -f2)"
-  versionMayorMinorPatch="$(echo "${versionMayorMinorPatchPre}" | cut -d'-' -f1)" # v0.0.0 (ignoring `-` if exists)
-  versionMayor="$(echo "${versionMayorMinorPatch}" | cut -d'.' -f1)" # v0
-  versionMinor="$(echo "${versionMayorMinorPatch}" | cut -d'.' -f2)"
-  versionMayorMinor="${versionMayor}.${versionMinor}" # v0.0
-  # by the moment we do not need it, versionPatch only for demo purposes
-  # versionPatch="$(echo "${versionMayorMinorPatch}" | cut -d'.' -f3)"
-
-  if [ -z "${versionBuild}" ]
-  then
-    canonicalTag=${versionMayorMinorPatchPre}
-  else
-    # because `+` is not accepted in tag names
-    canonicalTag=${versionMayorMinorPatchPre}_${versionBuild}
-  fi
-
-  if [ -n "${versionPre}" ]
-  then
-    preReleasePrefix="pre-"
-    versionMayor=${preReleasePrefix}${versionMayor}
-    versionMayorMinor=${preReleasePrefix}${versionMayorMinor}
-    versionMayorMinorPatch=${preReleasePrefix}${versionMayorMinorPatch}
-    versionMayorMinorPatchPre=${preReleasePrefix}${versionMayorMinorPatchPre}
-    versionFull=${preReleasePrefix}${versionFull}
-    canonicalTag=${preReleasePrefix}${canonicalTag}
-  fi
-  # endregion Ugly code to deal with versions
-fi
-
-if [ -n "${name}" ]
-then
-  versionFull=${name}-${commit}
-  canonicalTag=${versionFull}
-fi
-
-docker build . \
-  --build-arg baseUrl="${cdnBaseUrl}" \
-  --build-arg pkgName="${pkgName}" \
-  --build-arg version="${canonicalTag}" \
-  --tag "${canonicalTag}"
-
-# TODO: update this
-# BEGIN - Old behavior
 docker run --rm \
   -v /var/lib/jenkins/.ssh:/root/.ssh:ro \
-  "${canonicalTag}" \
+  "${tag}" \
   /bin/sh -c "\
-    scp -P \"${CDN_SFTP_PORT}\" -r \"/source/${pkgName}\" \"${CDN_SFTP_USERNAME}@${CDN_SFTP_HOSTNAME}:/${CDN_SFTP_BASE}/\""
-
-echo "Files ready in ${cdnBaseUrl}/${pkgName}/${canonicalTag}"
-# END - Old behavior
-
-# TODO: Implement this:
-# BEGIN - Desired Behavior
-echo "We should generate ${cdnBaseUrl}/${pkgName}/asset-manifest-${canonicalTag}.json"
-if [ -n "${version}" ]
-then
-  echo "We should generate ${cdnBaseUrl}/${pkgName}/asset-manifest-${versionMayor}.json"
-  echo "We should generate ${cdnBaseUrl}/${pkgName}/asset-manifest-${versionMayorMinor}.json"
-  echo "We should generate ${cdnBaseUrl}/${pkgName}/asset-manifest-${versionMayorMinorPatch}.json"
-  echo "We should generate ${cdnBaseUrl}/${pkgName}/asset-manifest-${versionMayorMinorPatchPre}.json"
-fi
-
-if [ -n "${name}" ]
-then
-  echo "We should generate ${cdnBaseUrl}/${pkgName}/asset-manifest-${name}.json"
-fi
-# END - Desired Behavior
+    sh ./prepare.sh \
+      --commit=\"${commit}\" \
+      --name=\"${name}\" \
+      --version=\"${version}\" \
+      --pre-version-suffix=\"${versionPre}\" \
+    && scp -P \"${CDN_SFTP_PORT}\" -r \"/work/build/.\" \"${CDN_SFTP_USERNAME}@${CDN_SFTP_HOSTNAME}:/${CDN_SFTP_BASE}/${pkgName}/${tag}/\""
+# TODO: use the prepared files (/work/ready) in place of build ones (/work/build) in SCP

--- a/cdn-helpers/prepare.sh
+++ b/cdn-helpers/prepare.sh
@@ -176,17 +176,23 @@ mkdir "${ready}" -p
 
 cp -R "${build}/static/." "${ready}/static"
 
+echo "${canonicalTag}" > "${ready}/asset-manifest-${canonicalTag}.txt"
 cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${canonicalTag}.json"
 
 if [ -n "${version}" ]
 then
+  echo "${canonicalTag}" > "${ready}/asset-manifest-${versionMayor}.txt"
   cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayor}.json"
+  echo "${canonicalTag}" > "${ready}/versiasset-manifeston-${versionMayorMinor}.txt"
   cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayorMinor}.json"
+  echo "${canonicalTag}" > "${ready}/asset-manifest-${versionMayorMinorPatch}.txt"
   cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayorMinorPatch}.json"
+  echo "${canonicalTag}" > "${ready}/asset-manifest-${versionMayorMinorPatchPre}.txt"
   cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayorMinorPatchPre}.json"
 fi
 
 if [ -n "${name}" ]
 then
+  echo "${canonicalTag}" > "${ready}/asset-manifest-${name}.txt"
   cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${name}.json"
 fi

--- a/cdn-helpers/prepare.sh
+++ b/cdn-helpers/prepare.sh
@@ -172,20 +172,21 @@ then
   canonicalTag=${versionFull}
 fi
 
-# TODO: implement the desired behavior described in the following echo lines
-echo We should copy "${build}/static" to "${ready}/static"
+mkdir "${ready}" -p
 
-echo We should copy "${build}/asset-manifest.json" to "${ready}/asset-manifest-${canonicalTag}.json"
+cp -R "${build}/static/." "${ready}/static"
+
+cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${canonicalTag}.json"
 
 if [ -n "${version}" ]
 then
-  echo We should copy "${build}/asset-manifest.json" to "${ready}/asset-manifest-${versionMayor}.json"
-  echo We should copy "${build}/asset-manifest.json" to "${ready}/asset-manifest-${versionMayorMinor}.json"
-  echo We should copy "${build}/asset-manifest.json" to "${ready}/asset-manifest-${versionMayorMinorPatch}.json"
-  echo We should copy "${build}/asset-manifest.json" to "${ready}/asset-manifest-${versionMayorMinorPatchPre}.json"
+  cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayor}.json"
+  cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayorMinor}.json"
+  cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayorMinorPatch}.json"
+  cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${versionMayorMinorPatchPre}.json"
 fi
 
 if [ -n "${name}" ]
 then
-  echo We should copy "${build}/asset-manifest.json" to "${ready}/asset-manifest-${name}.json"
+  cp "${build}/asset-manifest.json" "${ready}/asset-manifest-${name}.json"
 fi

--- a/cdn-helpers/prepare.sh
+++ b/cdn-helpers/prepare.sh
@@ -1,0 +1,191 @@
+#!/bin/sh
+
+# constants
+build="./build"
+ready="./ready"
+
+# parameters
+commit=""
+name=""
+version=""
+versionPre=""
+
+print_help () {
+    echo ""
+    echo "Usage: sh prepare.sh [OPTIONS]"
+    echo ""
+    echo "Prepare the files from ${build} folder with the required structure to upload the files to our CDN into the folder ${ready}"
+    echo ""
+    echo "Options:"
+    echo "  -c, --commit (mandatory)"
+    echo "  -n, --name, version name"
+    echo "  -v, --version, version number"
+    echo "  -s, --pre-version-suffix (optional, only with version)"
+    echo "  -h, --help"
+    echo "Only one of name or version parameters is required, and cannot be included together."
+    echo
+    echo "Examples:"
+    echo "  sh prepare.sh --commit=aee25c286a7c8265e2b32ccc293f5ab0bd7a9d57 --version=v1.2.11"
+    echo "  sh prepare.sh --c=aee25c286a7c8265e2b32ccc293f5ab0bd7a9d57 -v=v1.2.11"
+    echo "  sh prepare.sh --c=aee25c286a7c8265e2b32ccc293f5ab0bd7a9d57 -v=v1.2.11 -s=beta1"
+    echo "  sh prepare.sh --commit=aee25c286a7c8265e2b32ccc293f5ab0bd7a9d57 --version=v1.2.11 --pre-version-suffix=beta1"
+    echo "  sh prepare.sh --commit=aee25c286a7c8265e2b32ccc293f5ab0bd7a9d57 --name=main"
+}
+
+for i in "$@" ; do
+case $i in
+    -c=*|--commit=*)
+    commit="${i#*=}"
+    ;;
+    -n=*|--name=*)
+    name="${i#*=}"
+    ;;
+    -v=*|--version=*)
+    version="${i#*=}"
+    ;;
+    -s=*|--pre-version-suffix=*)
+    versionPre="${i#*=}"
+    ;;
+    -h|--help)
+    print_help
+    exit 0
+    ;;
+esac
+done
+
+if [ -z "${commit}" ]
+then
+  echo "Error: commit parameter is mandatory"
+  print_help
+  exit 1
+fi
+
+if [ -n "${version}" ] && [ -n "${name}" ]
+then
+  echo "Error: name and version parameters cannot be included together"
+  print_help
+  exit 1
+fi
+
+if [ -z "${version}" ] && [ -z "${name}" ]
+then
+  echo "Error: one of name or version parameters is required"
+  print_help
+  exit 1
+fi
+
+if [ -z "${version}" ] && [ -n "${versionPre}" ]
+then
+  echo "Error: pre-version-suffix parameter is only accepted along with version parameter"
+  print_help
+  exit 1
+fi
+
+# TODO: validate commit format
+# TODO: validate version format (if it is included)
+
+# Stop script on NZEC
+set -e
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
+
+# Lines added to get the script running in the script path shell context
+# reference: http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
+cd "$(dirname "$0")"
+
+# To avoid issues with MINGW and Git Bash, see:
+# https://github.com/docker/toolbox/issues/673
+# https://gist.github.com/borekb/cb1536a3685ca6fc0ad9a028e6a959e3
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL="*"
+
+if [ -n "${version}" ]
+then
+  versionBuild=${commit}
+  # Ugly code to deal with versions
+  # Input:
+  #   version=v12.34.5
+  #   versionBuild=94f85efb9c
+  #   versionPre=0pr
+  # Output:
+  #   versionMayor=pre-v12
+  #   versionMayorMinor=pre-v12.34
+  #   versionMayorMinorPatch=pre-v12.34.5
+  #   versionMayorMinorPatchPre=pre-v12.34.5-0pr
+  #   versionFull=pre-v12.34.5-0pr+94f85efb9c
+  #   versionFullForTag=pre-v12.34.5-0pr_94f85efb9c
+  # region Ugly code to deal with versions
+
+  versionFull=${version}
+
+  if [ -n "${versionPre}" ]
+  then
+    versionFull=${versionFull}-${versionPre}
+  fi
+
+  if [ -n "${versionBuild}" ]
+  then
+    versionFull=${versionFull}+${versionBuild}
+  fi
+
+  # https://semver.org/spec/v2.0.0.html#backusnaur-form-grammar-for-valid-semver-versions
+  # <valid semver> ::= <version core>
+  #                  | <version core> "-" <pre-release>
+  #                  | <version core> "+" <build>
+  #                  | <version core> "-" <pre-release> "+" <build>
+  #
+  # <version core> ::= <major> "." <minor> "." <patch>
+  versionBuild="$(echo "${versionFull}"+ | cut -d'+' -f2)"
+  versionMayorMinorPatchPre="$(echo "${versionFull}" | cut -d'+' -f1)" # v0.0.0-xxx (ignoring `+` if exists)
+  versionPre="$(echo "${versionMayorMinorPatchPre}"- | cut -d'-' -f2)"
+  versionMayorMinorPatch="$(echo "${versionMayorMinorPatchPre}" | cut -d'-' -f1)" # v0.0.0 (ignoring `-` if exists)
+  versionMayor="$(echo "${versionMayorMinorPatch}" | cut -d'.' -f1)" # v0
+  versionMinor="$(echo "${versionMayorMinorPatch}" | cut -d'.' -f2)"
+  versionMayorMinor="${versionMayor}.${versionMinor}" # v0.0
+  # by the moment we do not need it, versionPatch only for demo purposes
+  # versionPatch="$(echo "${versionMayorMinorPatch}" | cut -d'.' -f3)"
+
+  if [ -z "${versionBuild}" ]
+  then
+    canonicalTag=${versionMayorMinorPatchPre}
+  else
+    # because `+` is not accepted in tag names
+    canonicalTag=${versionMayorMinorPatchPre}_${versionBuild}
+  fi
+
+  if [ -n "${versionPre}" ]
+  then
+    preReleasePrefix="pre-"
+    versionMayor=${preReleasePrefix}${versionMayor}
+    versionMayorMinor=${preReleasePrefix}${versionMayorMinor}
+    versionMayorMinorPatch=${preReleasePrefix}${versionMayorMinorPatch}
+    versionMayorMinorPatchPre=${preReleasePrefix}${versionMayorMinorPatchPre}
+    versionFull=${preReleasePrefix}${versionFull}
+    canonicalTag=${preReleasePrefix}${canonicalTag}
+  fi
+  # endregion Ugly code to deal with versions
+fi
+
+if [ -n "${name}" ]
+then
+  versionFull=${name}-${commit}
+  canonicalTag=${versionFull}
+fi
+
+# TODO: implement the desired behavior described in the following echo lines
+echo We should copy "${build}/static" to "${ready}/static"
+
+echo We should copy "${build}/asset-manifest.json" to "${ready}/asset-manifest-${canonicalTag}.json"
+
+if [ -n "${version}" ]
+then
+  echo We should copy "${build}/asset-manifest.json" to "${ready}/asset-manifest-${versionMayor}.json"
+  echo We should copy "${build}/asset-manifest.json" to "${ready}/asset-manifest-${versionMayorMinor}.json"
+  echo We should copy "${build}/asset-manifest.json" to "${ready}/asset-manifest-${versionMayorMinorPatch}.json"
+  echo We should copy "${build}/asset-manifest.json" to "${ready}/asset-manifest-${versionMayorMinorPatchPre}.json"
+fi
+
+if [ -n "${name}" ]
+then
+  echo We should copy "${build}/asset-manifest.json" to "${ready}/asset-manifest-${name}.json"
+fi

--- a/cdn-helpers/upload.sh
+++ b/cdn-helpers/upload.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# constants
+ready="./ready"
+
+# parameters
+destination=""
+port=""
+
+print_help () {
+    echo ""
+    echo "Usage: sh upload.sh [OPTIONS]"
+    echo ""
+    echo "Upload the files from ${ready} folder to our CDN"
+    echo ""
+    echo "Options:"
+    echo "  -d, --destination (mandatory)"
+    echo "  -p, --port (Default value: 22)"
+    echo
+    echo "Examples:"
+    echo "  sh upload.sh --port 22 --destination=cdndoppler@reporting.fromdoppler.com:/cdndoppler/unlayer-editor/"
+}
+
+for i in "$@" ; do
+case $i in
+    -d=*|--destination=*)
+    destination="${i#*=}"
+    ;;
+    -p=*|--port=*)
+    port="${i#*=}"
+    ;;
+    -h|--help)
+    print_help
+    exit 0
+    ;;
+esac
+done
+
+if [ -z "${destination}" ]
+then
+  echo "Error: destination parameter is mandatory"
+  print_help
+  exit 1
+fi
+
+if [ -z "${port}" ]
+then
+  port=22
+fi
+
+# Stop script on NZEC
+set -e
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
+
+# Lines added to get the script running in the script path shell context
+# reference: http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
+cd "$(dirname "$0")"
+
+# To avoid issues with MINGW and Git Bash, see:
+# https://github.com/docker/toolbox/issues/673
+# https://gist.github.com/borekb/cb1536a3685ca6fc0ad9a028e6a959e3
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL="*"
+
+scp -P "${port}" -r "${ready}/." "${destination}"


### PR DESCRIPTION
Hi @paangaflo, @maurocardinali, and @Cromeror,

These changes allow us to upload the manifest files using _semantic version_ friendly names.

Here you can view the generated files in the CDN storage:

![image](https://user-images.githubusercontent.com/1157864/129197184-90e71e3b-4542-4c05-9b56-369cf1d6367c.png)
