### PR TITLE
DE-242 Basic config to multiple custom tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,17 +133,20 @@ Currently in Doppler [we are always using the v1](https://github.com/MakingSense
 
 ```html
 <html lang="en">
-<head>
+  <head>
     <!-- . . . -->
     <script src="https://cdn.fromdoppler.com/loader/v1/loader.js"></script>
-</head>
+  </head>
 
-<body>
+  <body>
     <!-- . . . -->
     <script type="text/javascript">
-        (new AssetServices()).load("https://cdn.fromdoppler.com/unlayer-editor/asset-manifest-v1.json", []);
+      new AssetServices().load(
+        'https://cdn.fromdoppler.com/unlayer-editor/asset-manifest-v1.json',
+        [],
+      );
     </script>
     <!-- . . . -->
-</body>
+  </body>
 </html>
 ```

--- a/public/socialTool.js
+++ b/public/socialTool.js
@@ -123,34 +123,3 @@ unlayer.registerTool({
     },
   },
 });
-
-/*const React = window.unlayer.React
-
-const Viewer = () => {
-    return React.createElement("div", null, "I am a custom tool.");
-}
-
-unlayer.registerTool({
-  name: 'my_tool',
-  label: 'My Tool',
-  icon: 'fa-smile',
-  supportedDisplayModes: ['web', 'email'],
-  options: {},
-  values: {},
-  renderer: {
-    Viewer: Viewer, // our React Viewer
-    exporters: {
-      web: function(values) {
-        return "<div>I am a custom tool.</div>"
-      },
-      email: function(values) {
-        return "<div>I am a custom tool.</div>"
-      }
-    },
-    head: {
-      css: function(values) {},
-      js: function(values) {}
-    }
-  }
-});
-*/

--- a/public/socialTool.js
+++ b/public/socialTool.js
@@ -118,7 +118,6 @@ unlayer.registerTool({
       },
     }),
     exporters: {
-      web: function () {},
       email: function () {},
     },
   },

--- a/public/socialTool.js
+++ b/public/socialTool.js
@@ -1,0 +1,156 @@
+unlayer.registerPropertyEditor({
+  name: 'facebook',
+  layout: 'bottom',
+  Widget: unlayer.createWidget({
+    render(value) {
+      return `
+        <div>
+          <input class="facebook" value=${value} />
+          <img alt="Facebook"
+              src="https://cdn2.iconfinder.com/data/icons/social-media-applications/64/social_media_applications_1-facebook-24.png" />
+        </div>
+      `;
+    },
+    mount(node, value, updateValue) {
+      var input = node.getElementsByClassName('facebook')[0];
+      input.onchange = function (event) {
+        updateValue(event.target.value);
+      };
+    },
+  }),
+});
+
+unlayer.registerPropertyEditor({
+  name: 'twitter',
+  layout: 'bottom',
+  Widget: unlayer.createWidget({
+    render(value) {
+      return `
+        <div>
+          <input class="color-value" value=${value} />
+          <img alt="Twitter"
+              src="https://cdn2.iconfinder.com/data/icons/social-media-applications/64/social_media_applications_6-twitter-24.png" />
+        </div>
+      `;
+    },
+    mount(node, value, updateValue) {
+      var input = node.getElementsByClassName('color-value')[0];
+      input.onchange = function (event) {
+        updateValue(event.target.value);
+      };
+    },
+  }),
+});
+
+unlayer.registerPropertyEditor({
+  name: 'linkedin',
+  layout: 'bottom',
+  Widget: unlayer.createWidget({
+    render(value) {
+      return `
+        <div>
+          <input class="color-value" value=${value} />
+          <img alt="Linkedin"
+              src="https://cdn2.iconfinder.com/data/icons/social-media-applications/64/social_media_applications_14-linkedin-24.png" />
+        </div>
+      `;
+    },
+    mount(node, value, updateValue) {
+      var input = node.getElementsByClassName('color-value')[0];
+      input.onchange = function (event) {
+        updateValue(event.target.value);
+      };
+    },
+  }),
+});
+
+unlayer.registerTool({
+  type: 'social-tool',
+  category: 'contents',
+  label: 'Social',
+  icon: 'fa-users',
+  values: {},
+  options: {
+    default: {
+      title: null,
+    },
+    link: {
+      title: 'Link',
+      position: 1,
+      options: {
+        facebook: {
+          label: 'Color',
+          defaultValue: 'www.facebook.com',
+          widget: 'facebook',
+        },
+        twitter: {
+          label: 'Color',
+          defaultValue: 'www.twitter.com',
+          widget: 'twitter',
+        },
+        linkedin: {
+          label: 'Color',
+          defaultValue: 'www.linkedin.com',
+          widget: 'linkedin',
+        },
+      },
+    },
+  },
+  renderer: {
+    Viewer: unlayer.createViewer({
+      render(values) {
+        return `
+          <p align="center">
+            <a style="text-decoration: none" href="${values.facebook}" target="_blank">
+            <img alt="Facebook"
+              src="https://cdn2.iconfinder.com/data/icons/social-media-applications/64/social_media_applications_1-facebook-32.png" />
+          </a>
+          <a style="text-decoration: none" href="${values.twitter}" target="_blank">
+            <img alt="Twitter"
+              src="https://cdn2.iconfinder.com/data/icons/social-media-applications/64/social_media_applications_6-twitter-32.png" />
+          </a>
+          <a style="text-decoration: none" href="${values.linkedin}" target="_blank">
+            <img alt="Linkedin"
+              src="https://cdn2.iconfinder.com/data/icons/social-media-applications/64/social_media_applications_14-linkedin-32.png" />
+          </a>
+          </p>
+        `;
+      },
+    }),
+    exporters: {
+      web: function () {},
+      email: function () {},
+    },
+  },
+});
+
+/*const React = window.unlayer.React
+
+const Viewer = () => {
+    return React.createElement("div", null, "I am a custom tool.");
+}
+
+unlayer.registerTool({
+  name: 'my_tool',
+  label: 'My Tool',
+  icon: 'fa-smile',
+  supportedDisplayModes: ['web', 'email'],
+  options: {},
+  values: {},
+  renderer: {
+    Viewer: Viewer, // our React Viewer
+    exporters: {
+      web: function(values) {
+        return "<div>I am a custom tool.</div>"
+      },
+      email: function(values) {
+        return "<div>I am a custom tool.</div>"
+      }
+    },
+    head: {
+      css: function(values) {},
+      js: function(values) {}
+    }
+  }
+});
+*/

--- a/public/subscribeTool.js
+++ b/public/subscribeTool.js
@@ -50,7 +50,6 @@ unlayer.registerTool({
       },
     }),
     exporters: {
-      web: function () {},
       email: function () {},
     },
   },

--- a/public/subscribeTool.js
+++ b/public/subscribeTool.js
@@ -1,0 +1,57 @@
+unlayer.registerPropertyEditor({
+  name: 'subscribe-editor',
+  layout: 'bottom',
+  Widget: unlayer.createWidget({
+    render(value) {
+      return `
+        <input class="unsubscribe-link" value=${value} />
+      `;
+    },
+    mount(node, value, updateValue) {
+      var input = node.getElementsByClassName('unsubscribe-link')[0];
+      input.onchange = function (event) {
+        updateValue(event.target.value);
+      };
+    },
+  }),
+});
+
+unlayer.registerTool({
+  type: 'subscribe-tool',
+  category: 'contents',
+  label: 'Subscribe',
+  icon: 'fa-bell',
+  values: {},
+  options: {
+    default: {
+      title: null,
+    },
+    link: {
+      title: 'Link',
+      position: 1,
+      options: {
+        unsubscribe: {
+          label: 'Unsubscribe',
+          defaultValue: 'www.unsubscribe.com',
+          widget: 'subscribe-editor',
+        },
+      },
+    },
+  },
+  renderer: {
+    Viewer: unlayer.createViewer({
+      render(values) {
+        return `
+          <p align="center">
+            If you'd like to unsubscribe and stop receiving these emails
+            <a target="_blank" href="${values.unsubscribe}">click here</a>.
+          </p>
+        `;
+      },
+    }),
+    exporters: {
+      web: function () {},
+      email: function () {},
+    },
+  },
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,30 @@
-import React, { useRef } from 'react';
+import React, { Component } from 'react';
 import './App.css';
 
 import EmailEditor from 'react-email-editor';
 
-const App: React.FC = () => {
-  const emailEditorRef = useRef(null);
-
-  return (
-    <div className="App" data-testid="email-editor-test">
-      <EmailEditor key="email-editor-test" ref={emailEditorRef} />
-    </div>
-  );
-};
+class App extends Component {
+  render(): JSX.Element {
+    return (
+      <div className="App" data-testid="email-editor-test">
+        <EmailEditor
+          projectId={1071}
+          options={{
+            customJS: [
+              window.location.protocol +
+                '//' +
+                window.location.host +
+                '/socialTool.js',
+              window.location.protocol +
+                '//' +
+                window.location.host +
+                '/subscribeTool.js',
+            ],
+          }}
+        />
+      </div>
+    );
+  }
+}
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,32 @@
-import React, { Component } from 'react';
+import React, { useRef } from 'react';
 import './App.css';
 
 import EmailEditor from 'react-email-editor';
 
-class App extends Component {
-  render(): JSX.Element {
-    return (
-      <div className="App" data-testid="email-editor-test">
-        <EmailEditor
-          projectId={1071}
-          options={{
-            customJS: [
-              window.location.protocol +
-                '//' +
-                window.location.host +
-                '/socialTool.js',
-              window.location.protocol +
-                '//' +
-                window.location.host +
-                '/subscribeTool.js',
-            ],
-          }}
-        />
-      </div>
-    );
-  }
-}
+const App: React.FC = () => {
+  const emailEditorRef = useRef(null);
+
+  return (
+    <div className="App" data-testid="email-editor-test">
+      <EmailEditor
+        projectId={1071}
+        key="email-editor-test"
+        ref={emailEditorRef}
+        options={{
+          customJS: [
+            window.location.protocol +
+              '//' +
+              window.location.host +
+              '/socialTool.js',
+            window.location.protocol +
+              '//' +
+              window.location.host +
+              '/subscribeTool.js',
+          ],
+        }}
+      />
+    </div>
+  );
+};
 
 export default App;


### PR DESCRIPTION
Feat: [DE-242](https://makingsense.atlassian.net/browse/DE-242)

El siguiente PR ilustra un ejemplo básico de como agregar múltiples custom tools a través de la opción CustomJS del editor Unlayer. Cada custom tools se agrega de manera independiente en su respetivo archivo JS encapsulando sus propiedades y lógica funcional.


Se agregará los siguientes custom tools:

1. socialTool.js: Es un componente que permite agregar los iconos de Facebook, Twitter y Linkedin para agregar en cada uno de ellos un hypervinculo. Esto se logra creando un properties custom para cada icono. 

![image](https://user-images.githubusercontent.com/8979304/129935915-a501ae38-518a-4886-b1c2-ca9f8dcbabb7.png)

2. subscribeTool.js: Es un componente que permite agregar un texto y un link de unsubscribe. Dentro de sus properties permite agregar el link al cual se debe referencia para hacer efectiva el unsubscribe.

![image](https://user-images.githubusercontent.com/8979304/129936985-dc954738-75db-453b-94d6-838f1fbff999.png)