### PR TITLE
chore(deps): configure dependabot to keep using node 14

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,8 @@ updates:
       include: scope
     ignore:
       - dependency-name: "node"
-        versions: ["15.x", "16.x"]
+        versions:
+        - ">= 15.0.0"
   - package-ecosystem: npm
     directory: "/"
     schedule:
@@ -24,4 +25,5 @@ updates:
       include: scope
     ignore:
       - dependency-name: "@types/node"
-        versions: ["15.x", "16.x"]
+        versions:
+        - ">= 15.0.0"


### PR DESCRIPTION
Dependabot still tries to update Node to v15: https://github.com/FromDoppler/unlayer-editor/pull/19

Maybe this other syntax works better, and if not, at least is cleanest.