### PR TITLE
DE-269 - Format validation fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,7 +28,7 @@ charset = utf-8-bom
 indent_style = tab
 
 # Unset for binary and generated files
-[{**.png,**.svg,**/obj/**,**/bin/**,.vscode/**,**/Properties/launchSettings.json,*.[sS]ecret.*,.doppler-ci}]
+[{**.png,**.svg,**/obj/**,**/bin/**,.vscode/**,**/Properties/launchSettings.json,*.[sS]ecret.*,.doppler-ci,build/**,coverage/**}]
 charset = unset
 end_of_line = unset
 insert_final_newline = unset

--- a/.prettierignore
+++ b/.prettierignore
@@ -29,4 +29,6 @@ package-lock.json
 *.svg
 *.png
 build/**
+.eslintrc.json
+.github/dependabot.yml
 coverage/**

--- a/.prettierignore
+++ b/.prettierignore
@@ -28,3 +28,5 @@ package-lock.json
 .*ignore
 *.svg
 *.png
+build/**
+coverage/**


### PR DESCRIPTION
Hi team, 

Prettier and EditorConfig were wrongly validating generated files (`build` and `coverage` folders). I change the configuration to ignore those files or their format.

Also, there are some files that Prettier does not know (`eslintrc.json` and `dependabot.yml`), so I added them to `.prettieringnore` file to hide some wrong warnings.

### Fixed errors and warnings:

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/1157864/130242091-2b40299b-96ce-458b-a7a0-da5366893c98.png">

<img width="758" alt="image" src="https://user-images.githubusercontent.com/1157864/130242506-1edf04d8-a589-4c43-aee9-77c238e22ed8.png">
