### PR TITLE
chore(build): fix release names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             branch 'main'
           }
           steps {
-            sh 'sh build-n-publish.sh --commit=${GIT_COMMIT} --name=main-${BUILD_NUMBER}'
+            sh 'sh build-n-publish.sh --commit=${GIT_COMMIT} --name=main'
           }
         }
         stage('Publish pre-release images from INT') {
@@ -55,7 +55,7 @@ pipeline {
             branch 'INT'
           }
           steps {
-            sh 'sh build-n-publish.sh --commit=${GIT_COMMIT} --name=INT-${BUILD_NUMBER}'
+            sh 'sh build-n-publish.sh --commit=${GIT_COMMIT} --name=INT'
           }
         }
         stage('Publish final version images') {


### PR DESCRIPTION
I am removing the build number suffix:

<img width="822" alt="image" src="https://user-images.githubusercontent.com/1157864/131006191-1e0b9a1b-b71a-46cf-87ce-b16d097f1b6c.png">
