### PR TITLE
fix: update manifest structure

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,14 +20,16 @@ const serializeManifest = (seed, files, entries) => {
 
     return {
         files: filesSerialized,
-        entrypoints: entries
+        entrypoints: entries.main
     };
 }
 
 module.exports = function (env) {
     Dotenv.config({path: './.env.' + env.NODE_ENV});
     return {
-        entry: './src/customJs/index.js',
+        entry: {
+          main: './src/customJs/index.js'
+        },
         mode: env.NODE_ENV ? env.NODE_ENV : 'development',
         output: {
             filename: env.NODE_ENV === 'production'


### PR DESCRIPTION
La nueva versión de Webpack va a buscar los assets a:
```
entrypoints: {
   main: {
      0: "xxxxx.js"
   }
}
```

Por esta razón hay que cambiar la estructura del manifest.