### PR TITLE
DE-562 - Customize Unlayer's default translated messages

### DIFF
--- a/src/customJs/localization.js
+++ b/src/customJs/localization.js
@@ -18,6 +18,7 @@ const sanitizeLanguageOrDefault = (lang) =>
 
 export const setLocale = (locale) => {
   window.unlayer.setLocale(locale);
+  window.unlayer.setTranslations(messages);
 
   intl = createIntl(
     {

--- a/src/customJs/localization.test.js
+++ b/src/customJs/localization.test.js
@@ -1,3 +1,5 @@
+import { messages_en } from '../i18n/en';
+import { messages_es } from '../i18n/es';
 import { intl, setLocale } from './localization';
 
 describe(setLocale.name, () => {
@@ -12,6 +14,23 @@ describe(setLocale.name, () => {
 
       // Assert
       expect(unlayerDouble.setLocale).toHaveBeenCalledWith(lang);
+    },
+  );
+
+  it.each([{ lang: 'es-ES' }, { lang: 'en-US' }, { lang: 'fr-FR' }])(
+    'should call Unlayer.setTranslations when language is $lang',
+    ({ lang }) => {
+      // Arrange
+      const unlayerDouble = prepareUnlayerGlobalObject();
+
+      // Act
+      setLocale(lang);
+
+      // Assert
+      expect(unlayerDouble.setTranslations).toHaveBeenCalledWith({
+        'en-US': messages_en,
+        'es-ES': messages_es,
+      });
     },
   );
 
@@ -38,6 +57,7 @@ describe(setLocale.name, () => {
 function prepareUnlayerGlobalObject() {
   window.unlayer = {
     setLocale: jest.fn(),
+    setTranslations: jest.fn(),
   };
   return window.unlayer;
 }

--- a/src/customJs/socialShareTool/index.test.js
+++ b/src/customJs/socialShareTool/index.test.js
@@ -31,6 +31,7 @@ describe(getSocialShareToolConfig.name, () => {
 function prepareUnlayerGlobalObject() {
   window.unlayer = {
     setLocale: jest.fn(),
+    setTranslations: jest.fn(),
   };
   return window.unlayer;
 }

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -5,4 +5,7 @@ export const messages_en = {
   size: `Size`,
   small: `Small`,
   social_networks: `Social networks`,
+  'tools.tabs.body': `General styles`,
+  'tools.tabs.images': `Stock images`,
+  'tools.tabs.uploads': `Gallery`,
 };

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -5,4 +5,7 @@ export const messages_es = {
   size: `Tamaño`,
   small: `Pequeño`,
   social_networks: `Redes sociales`,
+  'tools.tabs.body': `Estilos generales`,
+  'tools.tabs.images': `Imágenes de stock`,
+  'tools.tabs.uploads': `Galería`,
 };


### PR DESCRIPTION
It is an example of how to customize Unlayer's default translated messages.

<img width="831" alt="image" src="https://user-images.githubusercontent.com/1157864/163846924-81e130a6-1f7d-48ca-8f0a-23816bf55e86.png">

Only pay attention to the last commit, the other ones are part of #311 