### PR TITLE
fix: remove sms link type

### DIFF
--- a/src/customJs/index.js
+++ b/src/customJs/index.js
@@ -13,5 +13,12 @@ const unlayerLocale = unlayerLocales[locale] ?? unlayerLocales['es'];
 
 setLocale(unlayerLocale);
 
+unlayer.setLinkTypes([
+  {
+    name: 'sms',
+    enabled: false,
+  },
+]);
+
 // Register Properties and tool Social Share Tool
 unlayer.registerTool(getSocialShareToolConfig());


### PR DESCRIPTION
See documentation: https://docs.unlayer.com/docs/link-types

I had to run this code inside the Unlayer's IFrame, for that reason I made the change in [this repository](https://github.com/FromDoppler/unlayer-editor) and not in [Editors WebApp](https://github.com/FromDoppler/doppler-editors-webapp).

![image](https://user-images.githubusercontent.com/1157864/173592468-f6a0e549-f8e0-429e-a4e2-5556a606b936.png)
