### PR TITLE
Better types

### DIFF
--- a/src/customJs/properties/social_networks/SocialNetworksWidget.tsx
+++ b/src/customJs/properties/social_networks/SocialNetworksWidget.tsx
@@ -1,18 +1,18 @@
 import { React } from '../../unlayer-react';
-import { SocialNetworkId, WidgetComponent } from '../../types';
+import { BaseToolData, SocialNetworkId, WidgetComponent } from '../../types';
 import { Toggle } from '../../components/Toggle';
 import { SocialNetworksValue } from './SocialNetworksValue';
 
 type Option = { id: SocialNetworkId; name: string } & Record<string, any>;
 
-export const SocialNetworksWidget: WidgetComponent<SocialNetworksValue> = ({
+export const SocialNetworksWidget: WidgetComponent<
+  SocialNetworksValue,
+  void,
+  BaseToolData & { options?: Option[] }
+> = ({
   value: currentSelection = [],
   updateValue,
   data: { options = [] } = {},
-}: {
-  data: { options?: Option[] };
-  updateValue: (value: SocialNetworksValue) => void;
-  value: SocialNetworksValue;
 }) => {
   const updateSelection = (isChecked: boolean, id: SocialNetworkId) => {
     if (isChecked) {

--- a/src/customJs/properties/social_networks/index.ts
+++ b/src/customJs/properties/social_networks/index.ts
@@ -2,8 +2,10 @@ import { ReactPropertyDefinition } from '../../types';
 import { SocialNetworksValue } from './SocialNetworksValue';
 import { SocialNetworksWidget } from './SocialNetworksWidget';
 
-export const socialNetworksPropertyEditorDefinition: ReactPropertyDefinition<SocialNetworksValue> =
-  {
-    name: 'social_networks',
-    Widget: SocialNetworksWidget,
-  };
+export const socialNetworksPropertyEditorDefinition: ReactPropertyDefinition<
+  'social_networks',
+  SocialNetworksValue
+> = {
+  name: 'social_networks',
+  Widget: SocialNetworksWidget,
+};

--- a/src/customJs/properties/url/UrlWidget.tsx
+++ b/src/customJs/properties/url/UrlWidget.tsx
@@ -5,17 +5,13 @@ import { formatUrl } from '../../utils/url';
 import { UnlayerLabel } from '../../components/UnlayerLabel';
 import { UrlValue } from './UrlValue';
 
-export const UrlWidget: WidgetComponent<UrlValue> = ({
-  value,
-  updateValue,
-  data: { label, help },
-}: {
-  value: UrlValue;
-  updateValue: (v: UrlValue) => void;
-  data: { label: string; help?: ReactNode };
-}) => (
+export const UrlWidget: WidgetComponent<
+  UrlValue,
+  void,
+  { label?: string; help?: ReactNode }
+> = ({ value, updateValue, data: { label, help } }) => (
   <>
-    <UnlayerLabel label={label} />
+    <UnlayerLabel label={label ?? ''} />
     <div className="blockbuilder-widget-label mb-2">
       <div className="href_field input-group">
         <div className="input-group-prepend">

--- a/src/customJs/properties/url/index.ts
+++ b/src/customJs/properties/url/index.ts
@@ -2,7 +2,10 @@ import { ReactPropertyDefinition } from '../../types';
 import { UrlValue } from './UrlValue';
 import { UrlWidget } from './UrlWidget';
 
-export const urlPropertyEditorDefinition: ReactPropertyDefinition<UrlValue> = {
+export const urlPropertyEditorDefinition: ReactPropertyDefinition<
+  'url',
+  UrlValue
+> = {
   name: 'url',
   Widget: UrlWidget,
 };

--- a/src/customJs/types.ts
+++ b/src/customJs/types.ts
@@ -11,25 +11,37 @@ export type LinkType = 'phone' | 'email' | 'sms';
 
 export type ObjectWithStringProps = Record<string, any>;
 
-export type WidgetComponentProps<TPropertyValue, TToolValues = void> = {
+export type BaseToolData = {
+  label?: string;
+};
+
+export type WidgetComponentProps<
+  TPropertyValue,
+  TToolValues = void,
+  TToolData extends BaseToolData = BaseToolData,
+> = {
   value: TPropertyValue;
   updateValue: (v: TPropertyValue) => void;
-  // TODO: make d property generic, void by default
-  data: any;
+  data: TToolData;
   values: TToolValues;
 };
 
-export type WidgetComponent<TPropertyValue, TToolValues = void> = (
-  props: WidgetComponentProps<TPropertyValue, TToolValues>,
+export type WidgetComponent<
+  TPropertyValue,
+  TToolValues = void,
+  TToolData extends BaseToolData = BaseToolData,
+> = (
+  props: WidgetComponentProps<TPropertyValue, TToolValues, TToolData>,
 ) => ReactNode;
 
 export type ReactPropertyDefinition<
   TPropertyName extends string,
   TPropertyValue,
   TToolValues = void,
+  TToolData extends BaseToolData = BaseToolData,
 > = {
   name: TPropertyName;
-  Widget: WidgetComponent<TPropertyValue, TToolValues>;
+  Widget: WidgetComponent<TPropertyValue, TToolValues, TToolData>;
 };
 
 export type ReactProperty<TPropertyName extends string, TPropertyValue> = {

--- a/src/customJs/types.ts
+++ b/src/customJs/types.ts
@@ -11,8 +11,6 @@ export type LinkType = 'phone' | 'email' | 'sms';
 
 export type ObjectWithStringProps = Record<string, any>;
 
-export type ToolData = { name: string; label: string; icon: string };
-
 export type WidgetComponentProps<TPropertyValue, TToolValues = void> = {
   value: TPropertyValue;
   updateValue: (v: TPropertyValue) => void;
@@ -41,11 +39,13 @@ export type ReactProperty<TPropertyName extends string, TPropertyValue> = {
   // TODO: add other properties and remove & Record<any, any>;
 } & Record<any, any>;
 
+export type ToolInfo = { name: string; label: string; icon: string };
+
 export type ViewerComponentProps<TToolValues> = {
   values: TToolValues;
   displayMode: DisplayMode;
   isViewer: boolean;
-  toolData: ToolData;
+  toolInfo: ToolInfo;
 };
 
 export type ViewerComponent<TToolValues> = (

--- a/src/customJs/types.ts
+++ b/src/customJs/types.ts
@@ -13,33 +13,32 @@ export type ObjectWithStringProps = Record<string, any>;
 
 export type ToolData = { name: string; label: string; icon: string };
 
-export type WidgetComponent<T> = (props: {
-  value: T;
-  updateValue: (v: T) => void;
+export type WidgetComponent<TPropertyValue> = (props: {
+  value: TPropertyValue;
+  updateValue: (v: TPropertyValue) => void;
   // TODO: make d property generic, void by default
   data: any;
 }) => ReactNode;
 
-export type ReactPropertyDefinition<T> = {
+export type ReactPropertyDefinition<TPropertyValue> = {
   name: string;
-  Widget: WidgetComponent<T>;
+  Widget: WidgetComponent<TPropertyValue>;
 };
 
-export type ViewerComponent<T> = (props: {
-  values: T;
+export type ViewerComponent<TToolValues> = (props: {
+  values: TToolValues;
   displayMode: DisplayMode;
   isViewer: boolean;
   toolData: ToolData;
 }) => ReactNode;
 
-export type ReactToolDefinition<T> = {
+export type ReactToolDefinition<TToolValues> = {
   name: string;
   label: string;
   icon: string;
-  Component: ViewerComponent<T>;
+  Component: ViewerComponent<TToolValues>;
   // TODO: typify options
-  // T in ReactToolDefinition<T> should be the combination of the Ts of the widgets
-  // of these options
+  // TToolValues should be the combination of the TPropertyValues of these options
   options: ObjectWithStringProps;
   // TODO: typify validator
   validator?: ({
@@ -47,7 +46,7 @@ export type ReactToolDefinition<T> = {
     values,
   }: {
     defaultErrors: any;
-    values: T;
+    values: TToolValues;
   }) => any;
   // TODO: add other properties and remove & Record<any, any>;
 } & Record<any, any>;

--- a/src/customJs/types.ts
+++ b/src/customJs/types.ts
@@ -13,13 +13,17 @@ export type ObjectWithStringProps = Record<string, any>;
 
 export type ToolData = { name: string; label: string; icon: string };
 
-export type WidgetComponent<TPropertyValue, TToolValues = void> = (props: {
+export type WidgetComponentProps<TPropertyValue, TToolValues = void> = {
   value: TPropertyValue;
   updateValue: (v: TPropertyValue) => void;
   // TODO: make d property generic, void by default
   data: any;
   values: TToolValues;
-}) => ReactNode;
+};
+
+export type WidgetComponent<TPropertyValue, TToolValues = void> = (
+  props: WidgetComponentProps<TPropertyValue, TToolValues>,
+) => ReactNode;
 
 export type ReactPropertyDefinition<
   TPropertyName extends string,
@@ -30,12 +34,23 @@ export type ReactPropertyDefinition<
   Widget: WidgetComponent<TPropertyValue, TToolValues>;
 };
 
-export type ViewerComponent<TToolValues> = (props: {
+export type ReactProperty<TPropertyName extends string, TPropertyValue> = {
+  label: string;
+  defaultValue: TPropertyValue;
+  widget: TPropertyName;
+  // TODO: add other properties and remove & Record<any, any>;
+} & Record<any, any>;
+
+export type ViewerComponentProps<TToolValues> = {
   values: TToolValues;
   displayMode: DisplayMode;
   isViewer: boolean;
   toolData: ToolData;
-}) => ReactNode;
+};
+
+export type ViewerComponent<TToolValues> = (
+  props: ViewerComponentProps<TToolValues>,
+) => ReactNode;
 
 export type ReactToolDefinition<TToolValues> = {
   name: string;

--- a/src/customJs/types.ts
+++ b/src/customJs/types.ts
@@ -13,16 +13,17 @@ export type ObjectWithStringProps = Record<string, any>;
 
 export type ToolData = { name: string; label: string; icon: string };
 
-export type WidgetComponent<TPropertyValue> = (props: {
+export type WidgetComponent<TPropertyValue, TToolValues = void> = (props: {
   value: TPropertyValue;
   updateValue: (v: TPropertyValue) => void;
   // TODO: make d property generic, void by default
   data: any;
+  values: TToolValues;
 }) => ReactNode;
 
-export type ReactPropertyDefinition<TPropertyValue> = {
+export type ReactPropertyDefinition<TPropertyValue, TToolValues = void> = {
   name: string;
-  Widget: WidgetComponent<TPropertyValue>;
+  Widget: WidgetComponent<TPropertyValue, TToolValues>;
 };
 
 export type ViewerComponent<TToolValues> = (props: {

--- a/src/customJs/types.ts
+++ b/src/customJs/types.ts
@@ -21,8 +21,12 @@ export type WidgetComponent<TPropertyValue, TToolValues = void> = (props: {
   values: TToolValues;
 }) => ReactNode;
 
-export type ReactPropertyDefinition<TPropertyValue, TToolValues = void> = {
-  name: string;
+export type ReactPropertyDefinition<
+  TPropertyName extends string,
+  TPropertyValue,
+  TToolValues = void,
+> = {
+  name: TPropertyName;
   Widget: WidgetComponent<TPropertyValue, TToolValues>;
 };
 

--- a/src/customJs/utils/unlayer.tsx
+++ b/src/customJs/utils/unlayer.tsx
@@ -7,7 +7,7 @@ import {
   ObjectWithStringProps,
   ReactPropertyDefinition,
   ReactToolDefinition,
-  ToolData,
+  ToolInfo,
   ViewerComponent,
 } from '../types';
 import { getConfiguration } from '../configuration';
@@ -41,7 +41,7 @@ const createTool = <TToolValues,>({
   Component,
   ...restOfToolDefinitions
 }: ReactToolDefinition<TToolValues>) => {
-  const toolData: ToolData = { name, label, icon };
+  const toolInfo: ToolInfo = { name, label, icon };
   return {
     ...restOfToolDefinitions,
     name,
@@ -60,7 +60,7 @@ const createTool = <TToolValues,>({
           Component,
           displayMode,
           values,
-          toolData,
+          toolInfo,
           restOfViewerProps,
           restOfToolDefinitions,
         }),
@@ -70,7 +70,7 @@ const createTool = <TToolValues,>({
             Component,
             displayMode: 'web',
             values,
-            toolData,
+            toolInfo,
             restOfExporterParameters,
             restOfToolDefinitions,
           }),
@@ -79,7 +79,7 @@ const createTool = <TToolValues,>({
             Component,
             displayMode: 'email',
             values,
-            toolData,
+            toolInfo,
             restOfExporterParameters,
             restOfToolDefinitions,
           }),
@@ -92,14 +92,14 @@ const viewer = <TToolValues,>({
   Component,
   displayMode,
   values,
-  toolData,
+  toolInfo,
   restOfViewerProps,
   restOfToolDefinitions,
 }: {
   Component: ViewerComponent<TToolValues>;
   displayMode: DisplayMode;
   values: TToolValues;
-  toolData: ToolData;
+  toolInfo: ToolInfo;
   restOfViewerProps: ObjectWithStringProps;
   restOfToolDefinitions: ObjectWithStringProps;
 }) => {
@@ -109,7 +109,7 @@ const viewer = <TToolValues,>({
       Component,
       displayMode,
       isViewer,
-      toolData,
+      toolInfo,
       restOfViewerProps,
       restOfToolDefinitions,
       values,
@@ -122,7 +122,7 @@ const viewer = <TToolValues,>({
       values={values}
       displayMode={displayMode}
       isViewer={isViewer}
-      toolData={toolData}
+      toolInfo={toolInfo}
     />
   );
 };
@@ -131,14 +131,14 @@ const exporter = <TToolValues,>({
   Component,
   displayMode,
   values,
-  toolData,
+  toolInfo,
   restOfExporterParameters,
   restOfToolDefinitions,
 }: {
   Component: ViewerComponent<TToolValues>;
   displayMode: DisplayMode;
   values: TToolValues;
-  toolData: ToolData;
+  toolInfo: ToolInfo;
   restOfExporterParameters: ObjectWithStringProps;
   restOfToolDefinitions: ObjectWithStringProps;
 }) => {
@@ -151,7 +151,7 @@ const exporter = <TToolValues,>({
       Component,
       displayMode,
       isViewer,
-      toolData,
+      toolInfo,
       restOfExporterParameters,
       restOfToolDefinitions,
       values,
@@ -161,7 +161,7 @@ const exporter = <TToolValues,>({
       values={values}
       displayMode={displayMode}
       isViewer={isViewer}
-      toolData={toolData}
+      toolInfo={toolInfo}
     />,
   );
 };

--- a/src/customJs/utils/unlayer.tsx
+++ b/src/customJs/utils/unlayer.tsx
@@ -18,8 +18,16 @@ export const setLinkTypes = (
   linkTypes: { name: LinkType; enabled: boolean }[],
 ) => unlayer.setLinkTypes?.(linkTypes);
 
-export const registerPropertyEditor = <TPropertyValue,>(
-  propertyDefinition: ReactPropertyDefinition<TPropertyValue>,
+export const registerPropertyEditor = <
+  TPropertyName extends string,
+  TPropertyValue,
+  TToolValues,
+>(
+  propertyDefinition: ReactPropertyDefinition<
+    TPropertyName,
+    TPropertyValue,
+    TToolValues
+  >,
 ) => unlayer.registerPropertyEditor(propertyDefinition);
 
 export const registerReactTool = <TToolValues,>(

--- a/src/customJs/utils/unlayer.tsx
+++ b/src/customJs/utils/unlayer.tsx
@@ -18,20 +18,21 @@ export const setLinkTypes = (
   linkTypes: { name: LinkType; enabled: boolean }[],
 ) => unlayer.setLinkTypes?.(linkTypes);
 
-export const registerPropertyEditor = <T,>(
-  propertyDefinition: ReactPropertyDefinition<T>,
+export const registerPropertyEditor = <TPropertyValue,>(
+  propertyDefinition: ReactPropertyDefinition<TPropertyValue>,
 ) => unlayer.registerPropertyEditor(propertyDefinition);
 
-export const registerReactTool = <T,>(toolDefinition: ReactToolDefinition<T>) =>
-  unlayer.registerTool(createTool(toolDefinition));
+export const registerReactTool = <TToolValues,>(
+  toolDefinition: ReactToolDefinition<TToolValues>,
+) => unlayer.registerTool(createTool(toolDefinition));
 
-const createTool = <T,>({
+const createTool = <TToolValues,>({
   name,
   label,
   icon,
   Component,
   ...restOfToolDefinitions
-}: ReactToolDefinition<T>) => {
+}: ReactToolDefinition<TToolValues>) => {
   const toolData: ToolData = { name, label, icon };
   return {
     ...restOfToolDefinitions,
@@ -44,7 +45,7 @@ const createTool = <T,>({
         displayMode,
         ...restOfViewerProps
       }: {
-        values: T;
+        values: TToolValues;
         displayMode: DisplayMode;
       }) =>
         viewer({
@@ -56,7 +57,7 @@ const createTool = <T,>({
           restOfToolDefinitions,
         }),
       exporters: {
-        web: (values: T, ...restOfExporterParameters: any[]) =>
+        web: (values: TToolValues, ...restOfExporterParameters: any[]) =>
           exporter({
             Component,
             displayMode: 'web',
@@ -65,7 +66,7 @@ const createTool = <T,>({
             restOfExporterParameters,
             restOfToolDefinitions,
           }),
-        email: (values: T, ...restOfExporterParameters: any[]) =>
+        email: (values: TToolValues, ...restOfExporterParameters: any[]) =>
           exporter({
             Component,
             displayMode: 'email',
@@ -79,7 +80,7 @@ const createTool = <T,>({
   };
 };
 
-const viewer = <T,>({
+const viewer = <TToolValues,>({
   Component,
   displayMode,
   values,
@@ -87,9 +88,9 @@ const viewer = <T,>({
   restOfViewerProps,
   restOfToolDefinitions,
 }: {
-  Component: ViewerComponent<T>;
+  Component: ViewerComponent<TToolValues>;
   displayMode: DisplayMode;
-  values: T;
+  values: TToolValues;
   toolData: ToolData;
   restOfViewerProps: ObjectWithStringProps;
   restOfToolDefinitions: ObjectWithStringProps;
@@ -118,7 +119,7 @@ const viewer = <T,>({
   );
 };
 
-const exporter = <T,>({
+const exporter = <TToolValues,>({
   Component,
   displayMode,
   values,
@@ -126,9 +127,9 @@ const exporter = <T,>({
   restOfExporterParameters,
   restOfToolDefinitions,
 }: {
-  Component: ViewerComponent<T>;
+  Component: ViewerComponent<TToolValues>;
   displayMode: DisplayMode;
-  values: T;
+  values: TToolValues;
   toolData: ToolData;
   restOfExporterParameters: ObjectWithStringProps;
   restOfToolDefinitions: ObjectWithStringProps;


### PR DESCRIPTION
This PR improves the types.

Now, the properties have a complete type tying up the property name and the widget component type. Also, we have types for the parameter `values` (the tool's values) and `data` received by the widget. 

I had to rename the `toolData` property and the `ToolData` type as `toolInfo` and `ToolInfo` to avoid confusion with the `data` property of the tools.