### PR TITLE
Dop 1417 treat reponse with promo code items

### DIFF
--- a/src/customJs/properties/promo_codes/PromoCodesWidget.tsx
+++ b/src/customJs/properties/promo_codes/PromoCodesWidget.tsx
@@ -1,6 +1,10 @@
 import { React, useEffect, useState } from '../../unlayer-react';
 import { WidgetComponent } from '../../types';
-import { PromoCodesValue, StoreDependentToolValues } from './types';
+import {
+  PromoCodesValue,
+  StoreDependentToolValues,
+  PromoCodeItem,
+} from './types';
 import { EMPTY_SELECTION } from '../../constants';
 import { addUnlayerLabel } from '../../components/UnlayerLabel';
 import { requestDopplerApp } from '../../utils/dopplerAppBridge';
@@ -46,8 +50,9 @@ const usePromoCodes = ({ store }: { store: string }) => {
     const { destructor } = requestDopplerApp({
       action: 'getPromoCodes',
       store,
-      callback: (value: CodeOption[]) => {
-        setCodeOptions(value);
+      callback: (value: PromoCodeItem[]) => {
+        const itemsMapped = value.map((v) => mapCodeOption(v));
+        setCodeOptions(itemsMapped);
         setLoading(false);
       },
     });
@@ -59,4 +64,9 @@ const usePromoCodes = ({ store }: { store: string }) => {
     loading,
     codeOptions,
   };
+};
+
+const mapCodeOption = (item: PromoCodeItem): CodeOption => {
+  const label = item.type === 'money' ? `$${item.value}` : `${item.value}%`;
+  return { label: label, value: item.code };
 };

--- a/src/customJs/properties/promo_codes/types.ts
+++ b/src/customJs/properties/promo_codes/types.ts
@@ -6,3 +6,13 @@ export type StoresValue = string | EMPTY_SELECTION;
 export type StoreDependentToolValues = {
   store: StoresValue;
 };
+
+export type PromoCodeItem = {
+  code: string;
+  type: 'percent' | 'money';
+  value: number;
+  startDate: Date | undefined; // TODO: verify type
+  endDate: Date | undefined; // TODO: verify type
+  useLimit: number;
+  minPaymentAmount: number;
+};


### PR DESCRIPTION
En este caso la **opcion 3** se encuentra seleccionada (`codigo3`), la cual es de tipo `money` (la **opcion 1** es del mismo tipo, y la **opcion 2** de tipo `percent`):

![image](https://github.com/FromDoppler/unlayer-editor/assets/1985175/c7edbafe-4844-4bda-929d-1067f088c709)
