### PR TITLE
DOP-1420 Set promo code property

### DIFF
--- a/src/customJs/tools/promo_code/index.test.ts
+++ b/src/customJs/tools/promo_code/index.test.ts
@@ -55,6 +55,24 @@ describe(sut.name, () => {
       defaultValue: 'center',
       widget: 'alignment',
     });
+
+    expect(result?.options.default.options.backgroundColor).toEqual({
+      label: messages_es['editor.background_color.label'],
+      defaultValue: 'rgba(255,255,255, 0)',
+      widget: 'color_picker',
+    });
+
+    expect(result?.options.default.options.textColor).toEqual({
+      label: messages_es['editor.color.label'],
+      defaultValue: '#333333',
+      widget: 'color_picker',
+    });
+
+    expect(result?.options.default.options.fontSize).toEqual({
+      label: messages_es['editor.font_size.label'],
+      defaultValue: 36,
+      widget: 'font_size',
+    });
   });
 
   it('should return right store property when there is only a store with promotion code', () => {

--- a/src/customJs/tools/promo_code/index.ts
+++ b/src/customJs/tools/promo_code/index.ts
@@ -38,6 +38,21 @@ export const getPromoCodeToolDefinition: () =>
       default: {
         options: {
           alignment: alignmentProperty(),
+          backgroundColor: {
+            label: intl.formatMessage({ id: 'editor.background_color.label' }),
+            defaultValue: 'rgba(255,255,255, 0)',
+            widget: 'color_picker',
+          },
+          textColor: {
+            label: intl.formatMessage({ id: 'editor.color.label' }),
+            defaultValue: '#333333',
+            widget: 'color_picker',
+          },
+          fontSize: {
+            label: intl.formatMessage({ id: 'editor.font_size.label' }),
+            defaultValue: 36,
+            widget: 'font_size',
+          },
         },
       },
     },


### PR DESCRIPTION
Add property to set code promotion text style at the viewer

Note: exist a literal `'editor.text_color.label': Color del texto`, but I prefer to add a new: `Color de la fuente`

![image](https://github.com/FromDoppler/unlayer-editor/assets/83654756/6ae04cd8-9839-43dd-ab23-972de347979a)


https://github.com/FromDoppler/unlayer-editor/assets/83654756/e9f9fb49-6c9f-4b1f-8f85-f7aa372d2004


