### PR TITLE
Translation helper

### DIFF
--- a/src/customJs/localization.test.js
+++ b/src/customJs/localization.test.js
@@ -1,6 +1,6 @@
 import { messages_en } from '../i18n/en';
 import { messages_es } from '../i18n/es';
-import { intl, setLocale } from './localization';
+import { $t, setLocale } from './localization';
 
 describe(setLocale.name, () => {
   it.each([{ lang: 'es-ES' }, { lang: 'en-US' }, { lang: 'fr-FR' }])(
@@ -46,7 +46,7 @@ describe(setLocale.name, () => {
       setLocale(lang);
 
       // Act
-      const result = intl.formatMessage({ id: '_dp.size' });
+      const result = $t('_dp.size');
 
       // Assert
       expect(result).toEqual(expected_size_translation);

--- a/src/customJs/localization.ts
+++ b/src/customJs/localization.ts
@@ -2,6 +2,11 @@ import { createIntl, createIntlCache } from '@formatjs/intl';
 import { messages_en } from '../i18n/en';
 import { messages_es } from '../i18n/es';
 import type { IntlShape } from '@formatjs/intl';
+import {
+  FormatXMLElementFn,
+  PrimitiveType,
+  Options as IntlMessageFormatOptions,
+} from 'intl-messageformat';
 
 export type IntlMessages = typeof messages_es;
 export type IntlMessageId = keyof IntlMessages;
@@ -48,3 +53,9 @@ export const setLocale = (locale: AvailableLanguage) => {
     cache,
   );
 };
+
+export const $t = (
+  id: IntlMessageId,
+  values?: Record<string, PrimitiveType | FormatXMLElementFn<string, string>>,
+  opts?: IntlMessageFormatOptions,
+) => intl.formatMessage({ id }, values, opts);

--- a/src/customJs/properties/helpers.ts
+++ b/src/customJs/properties/helpers.ts
@@ -1,5 +1,5 @@
 import { EMPTY_SELECTION } from '../constants';
-import { intl } from '../localization';
+import { $t } from '../localization';
 import { Store } from '../types';
 
 const createOptions = <TValue extends string>(
@@ -8,7 +8,7 @@ const createOptions = <TValue extends string>(
   const defaultValue = items.length === 1 ? items[0].value : EMPTY_SELECTION;
   const emptyOption = {
     value: EMPTY_SELECTION,
-    label: intl.formatMessage({ id: '_dp.select_option' }),
+    label: $t('_dp.select_option'),
   } as const;
   const options = [emptyOption, ...items] as [
     { value: TValue | EMPTY_SELECTION; label: string },
@@ -67,10 +67,10 @@ export const smallBigDropdownProperty = ({
     defaultValue,
     options: [
       {
-        label: intl.formatMessage({ id: '_dp.small' }),
+        label: $t('_dp.small'),
         value: 'small',
       },
-      { label: intl.formatMessage({ id: '_dp.big' }), value: 'big' },
+      { label: $t('_dp.big'), value: 'big' },
     ] as const,
   });
 
@@ -86,26 +86,26 @@ export const smallMediumLargeDropdownProperty = ({
     defaultValue,
     options: [
       {
-        label: intl.formatMessage({ id: '_dp.small' }),
+        label: $t('_dp.small'),
         value: 'small',
       },
       {
-        label: intl.formatMessage({ id: '_dp.medium' }),
+        label: $t('_dp.medium'),
         value: 'medium',
       },
-      { label: intl.formatMessage({ id: '_dp.big' }), value: 'large' },
+      { label: $t('_dp.big'), value: 'large' },
     ] as const,
   });
 
 export const alignmentProperty = () => ({
-  label: intl.formatMessage({ id: 'editor.align.label' }),
+  label: $t('editor.align.label'),
   defaultValue: 'center' as const,
   widget: 'alignment',
 });
 
 export const storesDropdownProperty = ({ stores }: { stores: Store[] }) =>
   mappedDropdownProperty({
-    label: intl.formatMessage({ id: '_dp.store' }),
+    label: $t('_dp.store'),
     items: stores,
     map: ({ name }) => ({
       value: name,

--- a/src/customJs/properties/promo_codes/PromoCodesWidget.tsx
+++ b/src/customJs/properties/promo_codes/PromoCodesWidget.tsx
@@ -8,7 +8,7 @@ import {
 import { EMPTY_SELECTION } from '../../constants';
 import { addUnlayerLabel } from '../../components/UnlayerLabel';
 import { requestDopplerApp } from '../../utils/dopplerAppBridge';
-import { intl } from '../../localization';
+import { $t } from '../../localization';
 
 type CodeOption = { value: string; label: string };
 
@@ -46,14 +46,14 @@ export const PromoCodesWidget: WidgetComponent<
       <div style={loadingStyle}>
         <div className="spinner-border text-secondary" role="status"></div>
         <span className="visually-hidden" style={containerStyle}>
-          {intl.formatMessage({ id: 'labels.loading' })}...
+          {$t('labels.loading')}...
         </span>
       </div>
     );
   }
 
   return codeOptions.length === 0 ? (
-    <div>{intl.formatMessage({ id: '_dp.promo_codes_not_availables' })}</div>
+    <div>{$t('_dp.promo_codes_not_availables')}</div>
   ) : (
     <div role="container">
       {codeOptions.map((x) => (

--- a/src/customJs/properties/promo_codes/index.ts
+++ b/src/customJs/properties/promo_codes/index.ts
@@ -2,7 +2,7 @@ import { UnlayerProperty, ReactPropertyDefinition } from '../../types';
 import { PromoCodesValue, StoreDependentToolValues } from './types';
 import { PromoCodesWidget } from './PromoCodesWidget';
 import { EMPTY_SELECTION } from '../../constants';
-import { intl } from '../../localization';
+import { $t } from '../../localization';
 
 export const promoCodesPropertyEditor = 'promo_codes';
 type promoCodesPropertyEditor = typeof promoCodesPropertyEditor;
@@ -24,7 +24,7 @@ export const promoCodesProperty: (parameters?: {
 }: {
   label?: string;
 } = {}) => ({
-  label: label ?? intl.formatMessage({ id: '_dp.promo_codes' }),
+  label: label ?? $t('_dp.promo_codes'),
   defaultValue: EMPTY_SELECTION,
   widget: promoCodesPropertyEditor,
 });

--- a/src/customJs/properties/url/UrlWidget.tsx
+++ b/src/customJs/properties/url/UrlWidget.tsx
@@ -1,6 +1,6 @@
 import { React, ReactNode } from '../../unlayer-react';
 import { WidgetComponent } from '../../types';
-import { intl } from '../../localization';
+import { $t } from '../../localization';
 import { formatUrl } from '../../utils/url';
 import { addUnlayerLabel } from '../../components/UnlayerLabel';
 import { UrlValue } from './UrlValue';
@@ -11,9 +11,7 @@ export const UrlWidget: WidgetComponent<UrlValue, void, { help?: ReactNode }> =
       <div className="blockbuilder-widget-label mb-2">
         <div className="href_field input-group">
           <div className="input-group-prepend">
-            <span className="input-group-text">
-              {intl.formatMessage({ id: 'editor.link.url' })}
-            </span>
+            <span className="input-group-text">{$t('editor.link.url')}</span>
           </div>
           <input
             onBlur={(e) => {

--- a/src/customJs/tools/payu_button_tool/PayuButtonHelp.tsx
+++ b/src/customJs/tools/payu_button_tool/PayuButtonHelp.tsx
@@ -1,5 +1,5 @@
 import { React } from '../../unlayer-react';
-import { intl } from '../../localization';
+import { $t } from '../../localization';
 
 export const PayuButtonHelp = () => (
   <div
@@ -11,14 +11,14 @@ export const PayuButtonHelp = () => (
       fontFamily: 'Roboto,sans-serif',
     }}
   >
-    {intl.formatMessage({ id: '_dp.payu_help' })}{' '}
+    {$t('_dp.payu_help')}{' '}
     <a
       target="_blank"
       style={{ color: '#33AC72', textDecoration: 'none' }}
       rel="noreferrer"
-      href={intl.formatMessage({ id: '_dp.payu_help_link' })}
+      href={$t('_dp.payu_help_link')}
     >
-      {intl.formatMessage({ id: '_dp.help' })}
+      {$t('_dp.help')}
     </a>
   </div>
 );

--- a/src/customJs/tools/payu_button_tool/PayuButtonViewer.tsx
+++ b/src/customJs/tools/payu_button_tool/PayuButtonViewer.tsx
@@ -1,5 +1,5 @@
 import { React } from '../../unlayer-react';
-import { intl } from '../../localization';
+import { $t } from '../../localization';
 import { PayuButtonValues } from './types';
 import { ViewerComponent } from '../../types';
 
@@ -18,7 +18,7 @@ export const PayuButtonViewer: ViewerComponent<PayuButtonValues> = ({
       >
         <img
           style={{ width: buttonImgWidth }}
-          src={`${intl.formatMessage({ id: `_dp.payu_${size}_button` })}`}
+          src={$t(`_dp.payu_${size}_button`)}
           alt="payu_button"
         />
       </a>

--- a/src/customJs/tools/payu_button_tool/index.ts
+++ b/src/customJs/tools/payu_button_tool/index.ts
@@ -1,4 +1,4 @@
-import { intl } from '../../localization';
+import { $t } from '../../localization';
 import { PayuButtonViewer } from './PayuButtonViewer';
 import { ASSETS_BASE_URL } from '../../constants';
 import { ReactToolDefinitionFrom } from '../../types';
@@ -13,19 +13,19 @@ import {
 export const getPayuButtonToolDefinition: () => ReactToolDefinitionFrom<PayuButtonBase> =
   () => ({
     name: 'payu_button_tool',
-    label: intl.formatMessage({ id: '_dp.payu_button' }),
+    label: $t('_dp.payu_button'),
     icon: `${ASSETS_BASE_URL}/payu_button.svg`,
     Component: PayuButtonViewer,
     options: {
       basic_configuration_section: {
-        title: intl.formatMessage({ id: 'option_groups.button_options.title' }),
+        title: $t('option_groups.button_options.title'),
         options: {
           paymentURL: urlProperty({
-            label: intl.formatMessage({ id: '_dp.pay_button_link' }),
+            label: $t('_dp.pay_button_link'),
             help: PayuButtonHelp(),
           }),
           size: smallMediumLargeDropdownProperty({
-            label: intl.formatMessage({ id: '_dp.size' }),
+            label: $t('_dp.size'),
             defaultValue: 'medium',
           }),
           alignment: alignmentProperty(),
@@ -38,12 +38,10 @@ export const getPayuButtonToolDefinition: () => ReactToolDefinitionFrom<PayuButt
           id: 'CUSTOM_ERROR',
           icon: `${ASSETS_BASE_URL}/payu_button.svg`,
           severity: 'WARNING',
-          title: intl.formatMessage({
-            id: 'tabs.audit.rules.payu_button.empty_links.title',
-          }),
-          description: intl.formatMessage({
-            id: 'tabs.audit.rules.payu_button.empty_links.description',
-          }),
+          title: $t('tabs.audit.rules.payu_button.empty_links.title'),
+          description: $t(
+            'tabs.audit.rules.payu_button.empty_links.description',
+          ),
         });
       }
 

--- a/src/customJs/tools/promo_code/index.ts
+++ b/src/customJs/tools/promo_code/index.ts
@@ -1,4 +1,4 @@
-import { intl } from '../../localization';
+import { $t } from '../../localization';
 import { PromoCodeViewer } from './PromoCodeViewer';
 import { ReactToolDefinitionFrom } from '../../types';
 import { PromoCodeBase, PromoCodeValues } from './types';
@@ -24,12 +24,12 @@ export const getPromoCodeToolDefinition: () =>
 
   return {
     name: 'promo_code',
-    label: intl.formatMessage({ id: '_dp.promo_code' }),
+    label: $t('_dp.promo_code'),
     icon: `${ASSETS_BASE_URL}/promotion_code.svg`,
     Component: PromoCodeViewer,
     options: {
       promo_code: {
-        title: intl.formatMessage({ id: '_dp.promo_code' }),
+        title: $t('_dp.promo_code'),
         options: {
           store: storesDropdownProperty({ stores: storesWithPromoCode }),
           promo_code: promoCodesProperty(),
@@ -39,17 +39,17 @@ export const getPromoCodeToolDefinition: () =>
         options: {
           alignment: alignmentProperty(),
           backgroundColor: {
-            label: intl.formatMessage({ id: 'editor.background_color.label' }),
+            label: $t('editor.background_color.label'),
             defaultValue: 'rgba(255,255,255, 0)',
             widget: 'color_picker',
           },
           textColor: {
-            label: intl.formatMessage({ id: 'editor.color.label' }),
+            label: $t('editor.color.label'),
             defaultValue: '#333333',
             widget: 'color_picker',
           },
           fontSize: {
-            label: intl.formatMessage({ id: 'editor.font_size.label' }),
+            label: $t('editor.font_size.label'),
             defaultValue: '36px',
             widget: 'font_size',
           },

--- a/src/customJs/tools/social_share_tool/SocialShareViewer.tsx
+++ b/src/customJs/tools/social_share_tool/SocialShareViewer.tsx
@@ -1,5 +1,5 @@
 import { React } from '../../unlayer-react';
-import { intl } from '../../localization';
+import { $t } from '../../localization';
 import { SOCIAL_NETWORKS } from '../../constants';
 import { ViewerComponent } from '../../types';
 import { SocialShareValues } from './types';
@@ -40,9 +40,7 @@ export const SocialShareViewer: ViewerComponent<SocialShareValues> = ({
                     key={`social_button_${id}`}
                   >
                     <img
-                      src={intl.formatMessage({
-                        id: `_dp.social_share_url_${size}_${id}`,
-                      })}
+                      src={$t(`_dp.social_share_url_${size}_${id}`)}
                       alt={name}
                       width={size === 'big' ? '94' : '40'}
                       style={{

--- a/src/customJs/tools/social_share_tool/index.ts
+++ b/src/customJs/tools/social_share_tool/index.ts
@@ -1,4 +1,4 @@
-import { intl } from '../../localization';
+import { $t } from '../../localization';
 import { ASSETS_BASE_URL, SOCIAL_NETWORKS } from '../../constants';
 import { SocialShareViewer } from './SocialShareViewer';
 import { ReactToolDefinitionFrom } from '../../types';
@@ -9,12 +9,12 @@ import { smallBigDropdownProperty } from '../../properties/helpers';
 export const getSocialShareToolDefinition: () => ReactToolDefinitionFrom<SocialShareBase> =
   () => ({
     name: 'social_share_tool',
-    label: intl.formatMessage({ id: '_dp.social_share_title' }),
+    label: $t('_dp.social_share_title'),
     icon: `${ASSETS_BASE_URL}/share-node.svg`,
     Component: SocialShareViewer,
     options: {
       social_share_size: {
-        title: intl.formatMessage({ id: '_dp.size' }),
+        title: $t('_dp.size'),
         position: 1,
         options: {
           social_share_size: smallBigDropdownProperty({
@@ -24,7 +24,7 @@ export const getSocialShareToolDefinition: () => ReactToolDefinitionFrom<SocialS
         },
       },
       social_share_network: {
-        title: intl.formatMessage({ id: '_dp.social_networks' }),
+        title: $t('_dp.social_networks'),
         position: 2,
         options: {
           social_share_available: {
@@ -37,11 +37,11 @@ export const getSocialShareToolDefinition: () => ReactToolDefinitionFrom<SocialS
         },
       },
       social_share_align: {
-        title: intl.formatMessage({ id: '_dp.alignment' }),
+        title: $t('_dp.alignment'),
         position: 3,
         options: {
           social_share_align_option: {
-            label: intl.formatMessage({ id: '_dp.alignment' }),
+            label: $t('_dp.alignment'),
             defaultValue: 'center',
             widget: 'alignment',
           },


### PR DESCRIPTION
This PR adds a new helper `$t` to make `formatMessage` usage more convenient and less verbose.

I am still exposing `intl` because there are more functions, for example:

* `formatDateTimeRange`
* `formatDate`
* `formatTime`
* `formatDateToParts`
* `formatTimeToParts`
* `formatRelativeTime`
* `formatNumber`
* `formatNumberToParts`
* `formatPlural`
* `formatList`
* `formatList`
* `formatListToParts`
* `formatDisplayName`