### PR TITLE
DOP-1538 - Set default size value

### DIFF
--- a/src/customJs/tools/qr/index.ts
+++ b/src/customJs/tools/qr/index.ts
@@ -9,7 +9,7 @@ import { UnlayerProperty } from '../../types';
 
 export const sizeProperty: () => UnlayerProperty<number> = () => ({
   label: $t('_dp.size'),
-  defaultValue: 100,
+  defaultValue: 240,
   widget: 'counter',
 });
 


### PR DESCRIPTION
Fix: set 240 px as default QR size

![image](https://github.com/FromDoppler/unlayer-editor/assets/83654756/05f7a1ae-d6ca-451b-a7ac-61befceeb605)
