### PR TITLE
DOP-1661  - Save dynamic promo code settings

### DIFF
--- a/src/customJs/index.ts
+++ b/src/customJs/index.ts
@@ -19,6 +19,7 @@ import { DYNAMIC_TOOL_TYPE } from './constants';
 import { getRssHeaderToolDefinition } from './tools/rss';
 import { getQrToolDefinition } from './tools/qr';
 import { qrPropertyEditorDefinition } from './properties/qr';
+import { dynamicPromoCodePropertyEditorDefinition } from './properties/dynamic_promo_code';
 
 const {
   locale,
@@ -62,6 +63,7 @@ registerPropertyEditor(promoCodesPropertyEditorDefinition);
 registerPropertyEditor(productGalleryPropertyEditorDefinition);
 registerPropertyEditor(productArrangementPropertyEditorDefinition);
 registerPropertyEditor(qrPropertyEditorDefinition);
+registerPropertyEditor(dynamicPromoCodePropertyEditorDefinition);
 
 // Register Tools
 if (qrCode) {

--- a/src/customJs/properties/dynamic_promo_code/DynamicPromoCodeWidget.test.js
+++ b/src/customJs/properties/dynamic_promo_code/DynamicPromoCodeWidget.test.js
@@ -1,0 +1,74 @@
+import { React } from '../../unlayer-react';
+import { render, screen } from '@testing-library/react';
+import { DynamicPromoCodeWidget } from './DynamicPromoCodeWidget';
+
+import { requestDopplerApp } from '../../utils/dopplerAppBridge';
+import { setLocale } from '../../localization';
+
+// Required to initialize intl
+setLocale('es-ES');
+
+jest.mock('../../utils/dopplerAppBridge');
+jest.useFakeTimers();
+
+// TODO: this is a shared code, make it a common helper
+function prepareUnlayerGlobalObject() {
+  window.unlayer = {
+    setLocale: jest.fn(),
+    setTranslations: jest.fn(),
+  };
+  return window.unlayer;
+}
+
+describe('Dynamic Promocode widget', () => {
+  it('shoud call request and update the Id value ', async () => {
+    let unlayerPropertyProps = {
+      values: 'id',
+      updateValue: jest.fn(),
+      values: {
+        type: 'percent',
+        amount: '10',
+        expire_days: '10',
+        min_price: '10',
+        prefixe_code: '',
+        includes_shipping: false,
+        first_consumer_purchase: false,
+        combines_with_other_discounts: false,
+      },
+    };
+
+    requestDopplerApp.mockImplementation((params) => {
+      params.callback({
+        promoCodeId: 2024,
+      });
+    });
+
+    prepareUnlayerGlobalObject();
+    render(<DynamicPromoCodeWidget {...unlayerPropertyProps} />);
+    // valid wait rebounce
+    expect(requestDopplerApp).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(2000);
+    // valid after rebounce time call the request
+    expect(requestDopplerApp).toHaveBeenCalled();
+    expect(unlayerPropertyProps.updateValue).toHaveBeenCalledTimes(1);
+
+    render(<DynamicPromoCodeWidget {...unlayerPropertyProps} />);
+
+    // valid wait rebounce 2nd time
+    expect(unlayerPropertyProps.updateValue).toHaveBeenCalledTimes(1);
+    jest.advanceTimersByTime(2000);
+
+    // valid after rebounce time call the request 2nd time
+    expect(unlayerPropertyProps.updateValue).toHaveBeenCalledTimes(2);
+
+    // valid without update no request
+    jest.advanceTimersByTime(2000);
+    expect(unlayerPropertyProps.updateValue).toHaveBeenCalledTimes(2);
+
+    // valid update value with string
+    expect(unlayerPropertyProps.updateValue).not.toHaveBeenCalledWith(2024);
+
+    // valid update value with right data
+    expect(unlayerPropertyProps.updateValue).toHaveBeenCalledWith('2024');
+  });
+});

--- a/src/customJs/properties/dynamic_promo_code/DynamicPromoCodeWidget.tsx
+++ b/src/customJs/properties/dynamic_promo_code/DynamicPromoCodeWidget.tsx
@@ -23,7 +23,7 @@ export const dynamicPromoCodeWidget: WidgetComponent<
 }) => {
   useEffect(() => {
     updateValue(value);
-
+    const DEBOUNCE_TIME_MS = 2000; // 2 seg
     const dynamicProperties = {
       dynamicId: value,
       type: type,
@@ -44,7 +44,7 @@ export const dynamicPromoCodeWidget: WidgetComponent<
           updateValue(value);
         },
       });
-    }, 2000);
+    }, DEBOUNCE_TIME_MS);
     return () => clearTimeout(getData);
   }, [
     type,

--- a/src/customJs/properties/dynamic_promo_code/DynamicPromoCodeWidget.tsx
+++ b/src/customJs/properties/dynamic_promo_code/DynamicPromoCodeWidget.tsx
@@ -3,7 +3,7 @@ import { WidgetComponent } from '../../types';
 import { DynamicPromoCodeDependentToolValues } from './types';
 import { requestDopplerApp } from '../../utils/dopplerAppBridge';
 
-export const dynamicPromoCodeWidget: WidgetComponent<
+export const DynamicPromoCodeWidget: WidgetComponent<
   string,
   DynamicPromoCodeDependentToolValues,
   void

--- a/src/customJs/properties/dynamic_promo_code/DynamicPromoCodeWidget.tsx
+++ b/src/customJs/properties/dynamic_promo_code/DynamicPromoCodeWidget.tsx
@@ -1,0 +1,61 @@
+import { React, useEffect } from '../../unlayer-react';
+import { WidgetComponent } from '../../types';
+import { DynamicPromoCodeDependentToolValues } from './types';
+import { requestDopplerApp } from '../../utils/dopplerAppBridge';
+
+export const dynamicPromoCodeWidget: WidgetComponent<
+  string,
+  DynamicPromoCodeDependentToolValues,
+  void
+> = ({
+  value,
+  updateValue,
+  values: {
+    type,
+    amount,
+    expire_days,
+    min_price,
+    prefixe_code,
+    includes_shipping,
+    first_consumer_purchase,
+    combines_with_other_discounts,
+  },
+}) => {
+  useEffect(() => {
+    updateValue(value);
+
+    const dynamicProperties = {
+      dynamicId: value,
+      type: type,
+      value: amount,
+      expire_days: expire_days,
+      min_price: min_price,
+      prefixe_code: prefixe_code,
+      includes_shipping: includes_shipping,
+      first_consumer_purchase: first_consumer_purchase,
+      combines_with_other_discounts: combines_with_other_discounts,
+    };
+
+    const getData = setTimeout(() => {
+      requestDopplerApp({
+        action: 'getPromoCodeDynamicId',
+        dynamicProperties,
+        callback: (value: string) => {
+          updateValue(value);
+        },
+      });
+    }, 2000);
+    return () => clearTimeout(getData);
+  }, [
+    type,
+    amount,
+    expire_days,
+    min_price,
+    prefixe_code,
+    includes_shipping,
+    first_consumer_purchase,
+    combines_with_other_discounts,
+  ]);
+
+  return <></>;
+};

--- a/src/customJs/properties/dynamic_promo_code/DynamicPromoCodeWidget.tsx
+++ b/src/customJs/properties/dynamic_promo_code/DynamicPromoCodeWidget.tsx
@@ -3,6 +3,10 @@ import { WidgetComponent } from '../../types';
 import { DynamicPromoCodeDependentToolValues } from './types';
 import { requestDopplerApp } from '../../utils/dopplerAppBridge';
 
+type ResultDynamicPromoCodeId = {
+  promoCodeId: number;
+};
+
 export const DynamicPromoCodeWidget: WidgetComponent<
   string,
   DynamicPromoCodeDependentToolValues,
@@ -22,10 +26,9 @@ export const DynamicPromoCodeWidget: WidgetComponent<
   },
 }) => {
   useEffect(() => {
-    updateValue(value);
     const DEBOUNCE_TIME_MS = 2000; // 2 seg
     const dynamicProperties = {
-      dynamicId: value,
+      dynamic_id: value,
       type: type,
       value: amount,
       expire_days: expire_days,
@@ -40,8 +43,8 @@ export const DynamicPromoCodeWidget: WidgetComponent<
       requestDopplerApp({
         action: 'getPromoCodeDynamicId',
         dynamicProperties,
-        callback: (value: string) => {
-          updateValue(value);
+        callback: (value: ResultDynamicPromoCodeId) => {
+          updateValue(value.promoCodeId.toString());
         },
       });
     }, DEBOUNCE_TIME_MS);

--- a/src/customJs/properties/dynamic_promo_code/index.ts
+++ b/src/customJs/properties/dynamic_promo_code/index.ts
@@ -1,0 +1,26 @@
+import { ReactPropertyDefinition } from '../../types';
+import { dynamicPromoCodeWidget } from './DynamicPromoCodeWidget';
+import { DynamicPromoCodeDependentToolValues } from './types';
+
+export const dynamicPromoCodePropertyEditor = 'promo_dynamic_id';
+
+export const dynamicPromoCodePropertyEditorDefinition: ReactPropertyDefinition<
+  typeof dynamicPromoCodePropertyEditor,
+  string,
+  DynamicPromoCodeDependentToolValues,
+  void
+> = {
+  name: dynamicPromoCodePropertyEditor,
+  Widget: dynamicPromoCodeWidget,
+};
+
+export const dynamicIdProperty = ({
+  defaultValue,
+}: {
+  label?: string;
+  defaultValue?: string;
+} = {}) =>
+  ({
+    defaultValue,
+    widget: dynamicPromoCodePropertyEditor,
+  }) as const;

--- a/src/customJs/properties/dynamic_promo_code/index.ts
+++ b/src/customJs/properties/dynamic_promo_code/index.ts
@@ -1,5 +1,5 @@
 import { ReactPropertyDefinition } from '../../types';
-import { dynamicPromoCodeWidget } from './DynamicPromoCodeWidget';
+import { DynamicPromoCodeWidget } from './DynamicPromoCodeWidget';
 import { DynamicPromoCodeDependentToolValues } from './types';
 
 export const dynamicPromoCodePropertyEditor = 'promo_dynamic_id';
@@ -11,7 +11,7 @@ export const dynamicPromoCodePropertyEditorDefinition: ReactPropertyDefinition<
   void
 > = {
   name: dynamicPromoCodePropertyEditor,
-  Widget: dynamicPromoCodeWidget,
+  Widget: DynamicPromoCodeWidget,
 };
 
 export const dynamicIdProperty = ({

--- a/src/customJs/properties/dynamic_promo_code/types.ts
+++ b/src/customJs/properties/dynamic_promo_code/types.ts
@@ -1,0 +1,12 @@
+import { PromoCodeTypes } from '../../tools/promo_code/types';
+
+export type DynamicPromoCodeDependentToolValues = {
+  type: PromoCodeTypes;
+  amount: string;
+  expire_days: string;
+  min_price: string;
+  prefixe_code: string;
+  includes_shipping: boolean;
+  first_consumer_purchase: boolean;
+  combines_with_other_discounts: boolean;
+};

--- a/src/customJs/tools/promo_code/PromoCodeViewer.tsx
+++ b/src/customJs/tools/promo_code/PromoCodeViewer.tsx
@@ -14,16 +14,26 @@ export const PromoCodeViewer: ViewerComponent<PromoCodeValues> = ({
   return !values.isDynamic && values.code === EMPTY_SELECTION ? (
     <EmptyViewer {...rest} />
   ) : (
-    <div
-      style={{
-        textAlign: values.alignment,
-        backgroundColor: values.backgroundColor,
-      }}
-      role="container"
-    >
-      <span style={{ color: values.textColor, fontSize: values.fontSize }}>
-        {promoCodeValue}
-      </span>
+    <div>
+      <section
+        style={{
+          display: 'block',
+          padding: '5px',
+          textAlign: values.alignment,
+          backgroundColor: values.backgroundColor,
+        }}
+        role="container"
+      >
+        <span
+          style={{
+            color: values.textColor,
+            fontSize: values.fontSize,
+            width: '100%',
+          }}
+        >
+          {promoCodeValue}
+        </span>
+      </section>
     </div>
   );
 };

--- a/src/customJs/tools/promo_code/index.test.ts
+++ b/src/customJs/tools/promo_code/index.test.ts
@@ -3,6 +3,7 @@ import { messages_es } from '../../../i18n/es';
 import { __invalidateConfigurationCache } from '../../configuration';
 import { EMPTY_SELECTION } from '../../constants';
 import { setLocale } from '../../localization';
+import { PromoCodeValues } from './types';
 
 // Required to initialize intl
 setLocale('es-ES');
@@ -141,5 +142,293 @@ describe(sut.name, () => {
     });
     // When there is only one store, it is selected as default option
     expect(property.defaultValue).toBe(EMPTY_SELECTION);
+  });
+
+  it('should return right store property when there is only a store with dynamic promotion code', () => {
+    // Arrange
+    (window as any)['unlayer-extensions-configuration'] = {
+      stores: [
+        {
+          name: 'MercadoShops',
+          promotionCodeEnabled: false,
+          promotionCodeDynamicEnabled: false,
+        },
+        { name: 'Magento', promotionCodeEnabled: false },
+        {
+          name: 'Tiendanube',
+          promotionCodeEnabled: true,
+          promotionCodeDynamicEnabled: true,
+        },
+      ],
+    };
+
+    // Act
+    const result = sut();
+
+    // Assert
+    const propertyGroup = result!.options.store_promo_code;
+    expect(propertyGroup.title).toBe(messages_es['_dp.promo_code']);
+    const property = result!.options.store_promo_code.options.store;
+
+    expect(property.data.options).toContainEqual({
+      label: messages_es['_dp.select_option'],
+      value: EMPTY_SELECTION,
+    });
+    expect(property.data.options).toContainEqual({
+      label: 'Tiendanube',
+      value: 'Tiendanube',
+    });
+    // When there is only one store, it is selected as default option
+    expect(property.defaultValue).toBe('Tiendanube');
+  });
+
+  it('should view isDynamic property when a store is enabled to create a dynamic code', () => {
+    // Arrange
+    (window as any)['unlayer-extensions-configuration'] = {
+      stores: [
+        {
+          name: 'MercadoShops',
+          promotionCodeEnabled: false,
+          promotionCodeDynamicEnabled: false,
+        },
+        {
+          name: 'Tiendanube',
+          promotionCodeEnabled: true,
+          promotionCodeDynamicEnabled: true,
+        },
+      ],
+    };
+
+    // Act
+    const result = sut();
+    const states: any = result!.propertyStates!({
+      store: 'Tiendanube',
+    } as PromoCodeValues);
+    //Assert
+    expect(states.isDynamic.enabled).toEqual(true);
+
+    // act
+    const states2: any = result!.propertyStates!({
+      store: 'MercadoShops',
+    } as PromoCodeValues);
+    //Assert
+    expect(states2.isDynamic.enabled).toEqual(false);
+  });
+
+  it('should not view dynamic properties when is disabled isDynamic property', () => {
+    // Arrange
+    (window as any)['unlayer-extensions-configuration'] = {
+      stores: [
+        {
+          name: 'MercadoShops',
+          promotionCodeEnabled: false,
+          promotionCodeDynamicEnabled: false,
+        },
+        {
+          name: 'Tiendanube',
+          promotionCodeEnabled: true,
+          promotionCodeDynamicEnabled: true,
+        },
+      ],
+    };
+
+    // Act
+    const result = sut();
+    const states: any = result!.propertyStates!({
+      store: 'Tiendanube',
+    } as PromoCodeValues);
+    //Assert
+
+    expect(states.code.enabled).toEqual(true);
+    expect(states.type.enabled).toEqual(false || undefined);
+    expect(states.amount.enabled).toEqual(false || undefined);
+    expect(states.min_price.enabled).toEqual(false || undefined);
+    expect(states.expire_days.enabled).toEqual(false || undefined);
+    expect(states.advanced_options.enabled).toEqual(false || undefined);
+    expect(states.prefixe_code.enabled).toEqual(false || undefined);
+    expect(states.includes_shipping.enabled).toEqual(false || undefined);
+    expect(states.first_consumer_purchase.enabled).toEqual(false || undefined);
+    expect(states.combines_with_other_discounts.enabled).toEqual(
+      false || undefined,
+    );
+  });
+
+  it('should view dynamic properties when is enabled isDynamic property', () => {
+    // Arrange
+    (window as any)['unlayer-extensions-configuration'] = {
+      stores: [
+        {
+          name: 'MercadoShops',
+          promotionCodeEnabled: false,
+          promotionCodeDynamicEnabled: false,
+        },
+        {
+          name: 'Tiendanube',
+          promotionCodeEnabled: true,
+          promotionCodeDynamicEnabled: true,
+        },
+      ],
+    };
+
+    const mockPromoCodeValues = {
+      store: 'Tiendanube',
+      isDynamic: true,
+    };
+    // Act
+    const result = sut();
+    const states: any = result!.propertyStates!(
+      mockPromoCodeValues as PromoCodeValues,
+    );
+    //Assert
+
+    expect(states.code.enabled).toEqual(false);
+    expect(states.type.enabled).toEqual(true);
+    expect(states.amount.enabled).toEqual(true);
+    expect(states.min_price.enabled).toEqual(true);
+    expect(states.expire_days.enabled).toEqual(true);
+    expect(states.advanced_options.enabled).toEqual(true);
+    expect(states.prefixe_code.enabled).toEqual(false || undefined);
+    expect(states.includes_shipping.enabled).toEqual(false || undefined);
+    expect(states.first_consumer_purchase.enabled).toEqual(false || undefined);
+    expect(states.combines_with_other_discounts.enabled).toEqual(
+      false || undefined,
+    );
+  });
+
+  it('should view dynamic properties when is enabled isDynamic and advanced_options property', () => {
+    // Arrange
+    (window as any)['unlayer-extensions-configuration'] = {
+      stores: [
+        {
+          name: 'Tiendanube',
+          promotionCodeEnabled: true,
+          promotionCodeDynamicEnabled: true,
+        },
+      ],
+    };
+
+    const mockPromoCodeValues = {
+      store: 'Tiendanube',
+      isDynamic: true,
+      advanced_options: true,
+    };
+    // Act
+    const result = sut();
+    const states: any = result!.propertyStates!(
+      mockPromoCodeValues as PromoCodeValues,
+    );
+    //Assert
+    expect(states.prefixe_code.enabled).toEqual(true);
+    expect(states.includes_shipping.enabled).toEqual(true);
+    expect(states.first_consumer_purchase.enabled).toEqual(true);
+    expect(states.combines_with_other_discounts.enabled).toEqual(true);
+  });
+
+  it('should return dynamic properties in the default property group', () => {
+    // Arrange
+    (window as any)['unlayer-extensions-configuration'] = {
+      stores: [
+        {
+          name: 'Tiendanube',
+          promotionCodeEnabled: true,
+          promotionCodeDynamicEnabled: true,
+        },
+      ],
+    };
+
+    // Act
+    const result = sut();
+
+    // Assert
+    expect(result?.options.store_promo_code.options.isDynamic).toEqual({
+      label: messages_es['_dp.promo_code_coupon_type'],
+      defaultValue: false,
+      widget: 'toggle',
+    });
+
+    expect(result?.options.promo_code.options.code).toEqual({
+      label: messages_es['_dp.promo_codes'],
+      defaultValue: EMPTY_SELECTION,
+      widget: 'promo_codes',
+    });
+
+    expect(result?.options.dynamic_code.options.type).toEqual({
+      data: {
+        options: [
+          {
+            label: messages_es['_dp.promo_code_type_percent'],
+            value: 'percent',
+          },
+          { label: messages_es['_dp.promo_code_type_amount'], value: 'money' },
+          {
+            label: messages_es['_dp.promo_code_type_shipping'],
+            value: 'shipping',
+          },
+        ],
+      },
+      label: messages_es['_dp.promo_code_type'],
+      defaultValue: 'percent',
+      widget: 'dropdown',
+    });
+
+    expect(result?.options.dynamic_code.options.amount).toEqual({
+      label: messages_es['_dp.promo_code_dynamic_value'],
+      defaultValue: '5',
+      widget: 'text',
+    });
+
+    expect(result?.options.dynamic_code.options.expire_days).toEqual({
+      label: messages_es['_dp.promo_code_dynamic_validate_days'],
+      defaultValue: '45',
+      widget: 'text',
+    });
+
+    expect(result?.options.dynamic_code.options.min_price).toEqual({
+      label: messages_es['_dp.promo_code_dynamic_min_price'],
+      defaultValue: '0',
+      widget: 'text',
+    });
+
+    expect(result?.options.dynamic_code.options.dynamic_id).toEqual({
+      defaultValue: undefined,
+      widget: 'promo_dynamic_id',
+    });
+
+    expect(result?.options.dynamic_code.options.advanced_options).toEqual({
+      label: messages_es['_dp.promo_code_dynamic_advance_setting'],
+      defaultValue: false,
+      widget: 'toggle',
+    });
+
+    expect(result?.options.promo_code_advance.options.prefixe_code).toEqual({
+      label: messages_es['_dp.promo_code_dynamic_prefixe'],
+      defaultValue: undefined,
+      widget: 'text',
+    });
+
+    expect(
+      result?.options.promo_code_advance.options.includes_shipping,
+    ).toEqual({
+      label: messages_es['_dp.promo_code_dynamic_includes_shipping'],
+      defaultValue: false,
+      widget: 'toggle',
+    });
+
+    expect(
+      result?.options.promo_code_advance.options.first_consumer_purchase,
+    ).toEqual({
+      label: messages_es['_dp.promo_code_dynamic_first_consumer_purchase'],
+      defaultValue: false,
+      widget: 'toggle',
+    });
+
+    expect(
+      result?.options.promo_code_advance.options.combines_with_other_discounts,
+    ).toEqual({
+      label:
+        messages_es['_dp.promo_code_dynamic_combines_with_other_discounts'],
+      defaultValue: false,
+      widget: 'toggle',
+    });
   });
 });

--- a/src/customJs/tools/promo_code/index.ts
+++ b/src/customJs/tools/promo_code/index.ts
@@ -17,15 +17,13 @@ import { dynamicIdProperty } from '../../properties/dynamic_promo_code';
 export const getPromoCodeToolDefinition: () =>
   | ReactToolDefinitionFrom<PromoCodeBase>
   | undefined = () => {
-  const { stores, previewMode } = getConfiguration();
+  const { stores } = getConfiguration();
   const storesWithPromoCode = stores.filter(
     ({ promotionCodeEnabled }) => promotionCodeEnabled,
   );
 
-  /* WARN: remove preview mode when promotionCodeDynamicEnabled is Working */
   const storesWithPromoCodeDynamic = stores.filter(
-    ({ promotionCodeDynamicEnabled }) =>
-      promotionCodeDynamicEnabled || previewMode,
+    ({ promotionCodeDynamicEnabled }) => promotionCodeDynamicEnabled,
   );
 
   if (storesWithPromoCode.length === 0) {

--- a/src/customJs/tools/promo_code/index.ts
+++ b/src/customJs/tools/promo_code/index.ts
@@ -146,8 +146,9 @@ export const getPromoCodeToolDefinition: () =>
       },
       min_price: { enabled: values.isDynamic },
       expire_days: { enabled: values.isDynamic },
+      dynamic_id: { enabled: values.isDynamic },
       advanced_options: {
-        enabled: values.isDynamic && values.type !== 'shipping',
+        enabled: values.isDynamic,
       },
       prefixe_code: { enabled: values.isDynamic && values.advanced_options },
       includes_shipping: {

--- a/src/customJs/tools/promo_code/index.ts
+++ b/src/customJs/tools/promo_code/index.ts
@@ -47,6 +47,7 @@ export const getPromoCodeToolDefinition: () =>
     name: 'promo_code',
     label: $t('_dp.promo_code'),
     icon: `${ASSETS_BASE_URL}/promotion_code_v2.svg`,
+    is_dynamic: true,
     Component: PromoCodeViewer,
     options: {
       store_promo_code: {
@@ -165,6 +166,15 @@ export const getPromoCodeToolDefinition: () =>
     // See https://docs.unlayer.com/docs/transform-property-values
     transformer: (values: PromoCodeValues) => {
       return values;
+    },
+    createDynamicContet(htmlComponent: string, values: any) {
+      /* Set values.dynamic_id when request be working*/
+      const dynamic_id =
+        values.dynamic_id === undefined ? '10102024' : values.dynamic_id;
+      const htmlDinamicComponent = htmlComponent
+        .replace(/^.[div]*/, `<DynamicPromoCode dynamicId="${dynamic_id}"`)
+        .replace(/<\/div>$/, '</DynamicPromoCode>');
+      return htmlDinamicComponent;
     },
   };
 };

--- a/src/customJs/tools/promo_code/index.ts
+++ b/src/customJs/tools/promo_code/index.ts
@@ -12,6 +12,7 @@ import {
   textProperty,
   toggleShowProperty,
 } from '../../properties/helpers';
+import { dynamicIdProperty } from '../../properties/dynamic_promo_code';
 
 export const getPromoCodeToolDefinition: () =>
   | ReactToolDefinitionFrom<PromoCodeBase>
@@ -80,6 +81,7 @@ export const getPromoCodeToolDefinition: () =>
             label: $t('_dp.promo_code_dynamic_min_price'),
             defaultValue: '0',
           }),
+          dynamic_id: dynamicIdProperty(),
           advanced_options: toggleShowProperty({
             defaultValue: false,
             label: $t('_dp.promo_code_dynamic_advance_setting'),

--- a/src/customJs/tools/promo_code/types.ts
+++ b/src/customJs/tools/promo_code/types.ts
@@ -12,6 +12,7 @@ export type PromoCodeBase = {
     code: string | EMPTY_SELECTION;
   };
   dynamic_code: {
+    dynamic_id: string;
     expire_days: string;
     type: PromoCodeTypes;
     amount: string;

--- a/src/editorsWebappListenersRegistrator.ts
+++ b/src/editorsWebappListenersRegistrator.ts
@@ -1,4 +1,3 @@
-//import { DynamicPromoCodeDependentToolValues } from './customJs/tools/promo_code/types';
 import { DynamicPromoCodeDependentToolValues } from './customJs/properties/dynamic_promo_code/types';
 import { timeout } from './customJs/utils/promises';
 
@@ -93,7 +92,7 @@ export const registerListeners = () => {
     async (values: DynamicPromoCodeDependentToolValues) => {
       await timeout(1000);
       console.log('getPromoCodeDynamicId', values);
-      return '10102024';
+      return { promoCodeId: 10102024 };
     },
   );
 

--- a/src/editorsWebappListenersRegistrator.ts
+++ b/src/editorsWebappListenersRegistrator.ts
@@ -1,3 +1,5 @@
+//import { DynamicPromoCodeDependentToolValues } from './customJs/tools/promo_code/types';
+import { DynamicPromoCodeDependentToolValues } from './customJs/properties/dynamic_promo_code/types';
 import { timeout } from './customJs/utils/promises';
 
 const UNLAYER_ORIGIN = 'https://editor.unlayer.com';
@@ -85,6 +87,15 @@ export const registerListeners = () => {
     await timeout(1000);
     return promoCodesDummyValues[store.toLocaleLowerCase()] || [];
   });
+
+  registerListener(
+    'getPromoCodeDynamicId',
+    async (values: DynamicPromoCodeDependentToolValues) => {
+      await timeout(1000);
+      console.log('getPromoCodeDynamicId', values);
+      return '10102024';
+    },
+  );
 
   registerListener('getImageUrlFile', async (qrImageFile) => {
     console.log(qrImageFile);


### PR DESCRIPTION
Fix: add request to set dynamic Id for replace dynamic content 

[DOP-1661](https://makingsense.atlassian.net/browse/DOP-1661) (Unlayer subtask)

Request object

```
{
    "dynamicId": "10102024",
    "type": "percent",
    "value": "5",
    "expire_days": "45",
    "min_price": "0",
    "prefixe_code": "DOP",
    "includes_shipping": false,
    "first_consumer_purchase": false,
    "combines_with_other_discounts": false
}
```
see  "dynamicId": "10102024" with hardcode

HTML generate by this set

```
<DynamicPromoCode dynamicId="10102024" style="text-align:center;background-color:rgba(255,255,255, 0)" role="container">
      <span style="color:#333333;font-size:36px">[[[DC:COUPON_CODE]]]</span>
</DynamicPromoCode>
```
TODO: 

-  Remove previewMode when promotionCodeDynamicEnabled flag is available

[DOP-1661]: https://makingsense.atlassian.net/browse/DOP-1661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ