### PR TITLE
Dph #104 initialize editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "29.5.13",
-    "@types/node": "20.16.11",
+    "@types/node": "20.16.12",
     "@types/react": "18.3.11",
     "@types/react-dom": "18.3.1",
     "@types/react-email-editor": "1.5.6",

--- a/src/customJs/configuration.test.js
+++ b/src/customJs/configuration.test.js
@@ -30,6 +30,11 @@ const expectedDefaultConfiguration = {
   rssCampaign: false,
   rssShowPreview: false,
   previewMode: false,
+  socialShare: true,
+  payButton: true,
+  promoCode: true,
+  product: true,
+  qrCode: true,
   dopplerExternalUrls: {
     automation: '#',
     campaigns: '#',
@@ -77,6 +82,11 @@ describe(parseConfigurationDTO.name, () => {
     const crossSellingEnabled = false;
     const rssCampaign = false;
     const rssShowPreview = false;
+    const socialShare = false;
+    const payButton = false;
+    const promoCode = false;
+    const product = false;
+    const qrCode = false;
     const input = {
       locale,
       previewMode,
@@ -89,6 +99,11 @@ describe(parseConfigurationDTO.name, () => {
       crossSellingEnabled,
       rssCampaign,
       rssShowPreview,
+      socialShare,
+      payButton,
+      promoCode,
+      product,
+      qrCode,
     };
 
     // Act
@@ -109,6 +124,11 @@ describe(parseConfigurationDTO.name, () => {
       rssCampaign: false,
       rssShowPreview: false,
       previewMode,
+      socialShare: false,
+      payButton: false,
+      promoCode: false,
+      product: false,
+      qrCode: false,
       dopplerExternalUrls: {
         automation: '#',
         campaigns: '#',

--- a/src/customJs/configuration.ts
+++ b/src/customJs/configuration.ts
@@ -18,6 +18,11 @@ type Configuration = {
   rssCampaign: boolean;
   rssShowPreview: boolean;
   previewMode: boolean;
+  socialShare: boolean;
+  payButton: boolean;
+  promoCode: boolean;
+  product: boolean;
+  qrCode: boolean;
   dopplerExternalUrls: DopplerExternalUrls;
 };
 
@@ -58,6 +63,11 @@ export const parseConfigurationDTO = ({
   newProductsEnabled = false,
   rssCampaign = false,
   rssShowPreview = false,
+  socialShare = true,
+  payButton = true,
+  promoCode = true,
+  product = true,
+  qrCode = true,
 }: {
   locale?: 'es' | 'en';
   stores?: Store[];
@@ -72,6 +82,11 @@ export const parseConfigurationDTO = ({
   newProductsEnabled?: boolean;
   rssCampaign?: boolean;
   rssShowPreview?: boolean;
+  socialShare?: boolean;
+  payButton?: boolean;
+  promoCode?: boolean;
+  product?: boolean;
+  qrCode?: boolean;
 } = {}) => {
   stores = stores.map(parseStoreDTO);
   const promotionCodeEnabled = stores.some((x) => x.promotionCodeEnabled);
@@ -89,6 +104,11 @@ export const parseConfigurationDTO = ({
     rssCampaign,
     rssShowPreview,
     previewMode,
+    socialShare,
+    payButton,
+    promoCode,
+    product,
+    qrCode,
     dopplerExternalUrls: parseDopplerExternalUrlsDTO(dopplerExternalUrls),
   };
 };

--- a/src/customJs/index.ts
+++ b/src/customJs/index.ts
@@ -31,6 +31,11 @@ const {
   crossSellingEnabled,
   newProductsEnabled,
   rssCampaign,
+  socialShare,
+  payButton,
+  promoCode,
+  product,
+  qrCode,
 } = getConfiguration();
 
 const unlayerLocales = {
@@ -48,7 +53,7 @@ setLinkTypes?.([
   },
 ]);
 
-// Register Properties and tools
+// Register Properties
 
 registerPropertyEditor(urlPropertyEditorDefinition);
 registerPropertyEditor(promoCodesPropertyEditorDefinition);
@@ -56,11 +61,26 @@ registerPropertyEditor(productGalleryPropertyEditorDefinition);
 registerPropertyEditor(productArrangementPropertyEditorDefinition);
 registerPropertyEditor(qrPropertyEditorDefinition);
 
-registerReactTool(getSocialShareToolDefinition());
-registerReactTool(getPayuButtonToolDefinition());
-registerReactTool(getPromoCodeToolDefinition());
-registerReactTool(getProductToolDefinition());
-registerReactTool(getQrToolDefinition());
+// Register Tools
+if (qrCode) {
+  registerReactTool(getQrToolDefinition());
+}
+
+if (product) {
+  registerReactTool(getProductToolDefinition());
+}
+
+if (promoCode) {
+  registerReactTool(getPromoCodeToolDefinition());
+}
+
+if (socialShare) {
+  registerReactTool(getSocialShareToolDefinition());
+}
+
+if (payButton) {
+  registerReactTool(getPayuButtonToolDefinition());
+}
 
 if (abandonedCartCampaign) {
   registerReactTool(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,10 +1972,10 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@20.16.11":
-  version "20.16.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.11.tgz#9b544c3e716b1577ac12e70f9145193f32750b33"
-  integrity sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==
+"@types/node@20.16.12":
+  version "20.16.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.12.tgz#61cc9be049584b472fa31e465aa0ab3c090dac56"
+  integrity sha512-LfPFB0zOeCeCNQV3i+67rcoVvoN5n0NVuR2vLG0O5ySQMgchuZlC4lgz546ZOJyDtj5KIgOxy+lacOimfqZAIA==
   dependencies:
     undici-types "~6.19.2"
 


### PR DESCRIPTION
To use unlayer-editor effectively for popup design, we need to implement optional custom tool configuration at initialization. This allows us to select which tools to activate based on the specific popup widget being edited.