### PR TITLE
DOP-1647 - Add promocode validator

### DIFF
--- a/src/customJs/tools/promo_code/index.ts
+++ b/src/customJs/tools/promo_code/index.ts
@@ -162,6 +162,20 @@ export const getPromoCodeToolDefinition: () =>
         enabled: values.isDynamic && values.advanced_options,
       },
     }),
+    validator: ({ defaultErrors, values }) => {
+      if (values.isDynamic && !values.dynamic_id) {
+        defaultErrors.push({
+          id: 'PROMO_CODE_DYNAMIC_ID_REQUIRED_ERROR',
+          icon: `${ASSETS_BASE_URL}/promotion_code_audit1.svg`,
+          severity: 'ERROR',
+          title: $t('tabs.audit.rules.promo_code.id_undefined.title'),
+          description: $t(
+            'tabs.audit.rules.promo_code.id_undefined.description',
+          ),
+        });
+      }
+      return defaultErrors;
+    },
     // See https://docs.unlayer.com/docs/transform-property-values
     transformer: (values: PromoCodeValues) => {
       return values;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -617,6 +617,8 @@ export const messages_en: IntlMessages = {
   'tabs.audit.rules.menu.empty_links.title': `Menu links are empty`,
   'tabs.audit.rules.payu_button.empty_links.description': `Without a link, PayU buttons will not work when a user clicks on it. Add a link to the following PayU buttons.`,
   'tabs.audit.rules.payu_button.empty_links.title': `PayU button links are empty`,
+  'tabs.audit.rules.promo_code.id_undefined.description': `Automations require the dynamic code to be correctly configured.`,
+  'tabs.audit.rules.promo_code.id_undefined.title': `The dynamic promotion code required to be set`,
   'tabs.audit.take_me_to_fix': `Take me to fix`,
   'tones.bold': `Bold`,
   'tones.friendly': `Friendly`,

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -617,6 +617,8 @@ export const messages_es = {
   'tabs.audit.rules.menu.empty_links.title': `Los enlaces del menú están vacíos`,
   'tabs.audit.rules.payu_button.empty_links.description': `Los botones de pago PayU no funcionarán cuando el usuario los pulse si no tienen enlace de solicitud de pago. Añade un enlace a los siguientes botones.`,
   'tabs.audit.rules.payu_button.empty_links.title': `Los enlaces de solicitud de pago en los botones de pago PayU están vacíos`,
+  'tabs.audit.rules.promo_code.id_undefined.description': `Las automatizaciones necesitan que se encuentre correctamente configurado el código dinámico`,
+  'tabs.audit.rules.promo_code.id_undefined.title': `El código de promoción dinámico requiere configurarse.`,
   'tabs.audit.take_me_to_fix': `Llévame a arreglarlo`,
   'tones.bold': `Atrevido`,
   'tones.friendly': `Amistoso`,


### PR DESCRIPTION
fix: add validation for undefined dynamic id on promo code tool when it is dynamic

![audit 1](https://github.com/user-attachments/assets/ad30bab8-ecb9-4e7b-9fad-61202be1da60)

![audit 2](https://github.com/user-attachments/assets/880dd2c4-1149-4f2d-9a2e-1dbd650ee2d3)
