### PR TITLE
DOP-1729 - Add target property for link at  dynamic product

### DIFF
--- a/src/customJs/tools/dynamic_tool/ProductViewer.test.jsx
+++ b/src/customJs/tools/dynamic_tool/ProductViewer.test.jsx
@@ -376,6 +376,7 @@ describe(ProductViewer.name, () => {
     it('should render buy button with link dynamic url product', async () => {
       const values = {
         buttonShown: true,
+        buttonTarget: '_blank',
         buttonText: 'Comprar',
       };
       /* NOTE: html add http://localhost/ when the link is a string */
@@ -383,6 +384,18 @@ describe(ProductViewer.name, () => {
       const button = screen.getByText('Comprar');
       expect(button.href).toEqual('http://localhost/[[[DC:URL]]]');
       expect(button.target).toEqual('_blank');
+    });
+
+    it('should render buy button with target at the same tab', async () => {
+      const values = {
+        buttonShown: true,
+        buttonText: 'Comprar',
+        buttonTarget: '_self',
+      };
+      /* NOTE: html add http://localhost/ when the link is a string */
+      render(<ProductViewer values={values} {...rest} />);
+      const button = screen.getByText('Comprar');
+      expect(button.target).toEqual('_self');
     });
 
     it('should render image with style width 100% when autoWidth is true', async () => {

--- a/src/customJs/tools/dynamic_tool/ProductViewer.tsx
+++ b/src/customJs/tools/dynamic_tool/ProductViewer.tsx
@@ -150,6 +150,7 @@ export const ProductViewer: ViewerComponent<ProductValues> = ({
     },
     button: {
       value: values.buttonText,
+      target: values.buttonTarget || '_blank',
       href: '[[[DC:URL]]]',
       style: buttonStyle,
     },
@@ -174,7 +175,7 @@ export const ProductViewer: ViewerComponent<ProductValues> = ({
             <a
               role="link"
               href={productToolElement.button.href}
-              target="_blank"
+              target={productToolElement.button.target}
               rel="noreferrer"
             >
               <img
@@ -204,7 +205,7 @@ export const ProductViewer: ViewerComponent<ProductValues> = ({
               style={productToolElement.button.style}
               role="link"
               href={productToolElement.button.href}
-              target="_blank"
+              target={productToolElement.button.target}
               rel="noreferrer"
             >
               {productToolElement.button.value}

--- a/src/customJs/tools/dynamic_tool/index.ts
+++ b/src/customJs/tools/dynamic_tool/index.ts
@@ -21,6 +21,7 @@ import {
   recommendedStructureProperty,
   productLayoutProperty,
   atributesByToolType,
+  linkTargettProperty,
 } from './propertyHelper';
 
 const DEFAULT_GREEN_COLOR = '#64BF91';
@@ -151,6 +152,7 @@ export const getDynamicToolDefinition: (
       title: $t('_dp.product_button'),
       options: {
         buttonShown: toggleShowProperty(),
+        buttonTarget: linkTargettProperty(),
         buttonText: textProperty({
           label: $t('_dp.product_button_text'),
           defaultValue: $t('_dp.product_button_default_value'),

--- a/src/customJs/tools/dynamic_tool/propertyHelper.ts
+++ b/src/customJs/tools/dynamic_tool/propertyHelper.ts
@@ -9,6 +9,7 @@ import {
   RecommendedStructure,
   RecommendedType,
   OptionTool,
+  LinkTarget,
 } from './types';
 
 const { bestSellingEnabled, crossSellingEnabled, newProductsEnabled } =
@@ -21,6 +22,16 @@ export const productLayoutProperty: () => UnlayerProperty<ProductLayout> = () =>
     options: [
       { label: $t('_dp.layout_00_horizontal'), value: '00_horizontal' },
       { label: $t('_dp.layout_01_vertical'), value: '01_vertical' },
+    ],
+  } as const);
+
+export const linkTargettProperty: () => UnlayerProperty<LinkTarget> = () =>
+  dropdownProperty({
+    label: $t('editor.link.target'),
+    defaultValue: '_blank',
+    options: [
+      { label: $t('editor.link.new_tab'), value: '_blank' },
+      { label: $t('editor.link.same_tab'), value: '_self' },
     ],
   } as const);
 

--- a/src/customJs/tools/dynamic_tool/types.ts
+++ b/src/customJs/tools/dynamic_tool/types.ts
@@ -31,6 +31,7 @@ export type OptionTool =
   | 'quantity'
   | 'price'
   | 'button';
+export type LinkTarget = '_self' | '_blank';
 
 export type ProductBase = Readonly<{
   product: {
@@ -89,6 +90,7 @@ export type ProductBase = Readonly<{
   };
   button: {
     buttonShown: boolean;
+    buttonTarget: LinkTarget;
     buttonText: string;
     buttonFont: FontFamily;
     buttonFontWeight: FontWeight;


### PR DESCRIPTION
Fix: add target property for image link and button link at dynamic product

![image](https://github.com/user-attachments/assets/fab99350-050a-4bed-8250-aee12e34021b)
