### PR TITLE
DOP-1763 - Add audit rule for silde incomplete

### DIFF
--- a/src/customJs/tools/wheel/index.ts
+++ b/src/customJs/tools/wheel/index.ts
@@ -252,7 +252,7 @@ export const getWheelFortuneToolDefinition: () =>
       if (values.list === '-1') {
         defaultErrors.push({
           id: 'SMART_FORM_TARGET_LIST_REQUIRED_ERROR',
-          icon: `${ASSETS_BASE_URL}/form1.svg`,
+          icon: `${ASSETS_BASE_URL}/roulette2.svg`,
           severity: 'ERROR',
           title: $t(
             'tabs.audit.rules.smart_form.subscription_list_undefined.title',
@@ -262,6 +262,25 @@ export const getWheelFortuneToolDefinition: () =>
           ),
         });
       }
+      const wheelListIncomplete = values.wheelList.some(
+        (wheelSlide: WheelSlide) => {
+          return (
+            wheelSlide.label.trim() === '' || wheelSlide.gift.trim() === ''
+          );
+        },
+      );
+      if (wheelListIncomplete) {
+        defaultErrors.push({
+          id: 'ROULETTE_WHEEL_LIST_INCOMPLETED_ERROR',
+          icon: `${ASSETS_BASE_URL}/roulette2.svg`,
+          severity: 'ERROR',
+          title: $t('tabs.audit.rules.roulette.wheel_list_incomplete.title'),
+          description: $t(
+            'tabs.audit.rules.roulette.wheel_list_incomplete.description',
+          ),
+        });
+      }
+
       return defaultErrors;
     },
   };

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -660,6 +660,8 @@ export const messages_en: IntlMessages = {
   'tabs.audit.rules.payu_button.empty_links.title': `PayU button links are empty`,
   'tabs.audit.rules.promo_code.id_undefined.description': `Automations require the dynamic code to be correctly configured.`,
   'tabs.audit.rules.promo_code.id_undefined.title': `The dynamic promotion code required to be set`,
+  'tabs.audit.rules.roulette.wheel_list_incomplete.description': `To continue, you must complete the roulette's slides`,
+  'tabs.audit.rules.roulette.wheel_list_incomplete.title': `Complete the Rouletter`,
   'tabs.audit.rules.smart_form.congrats_message_undefined.description': `To continue, you must write a Thank You Message, which your customers will see when they complete the Form.`,
   'tabs.audit.rules.smart_form.congrats_message_undefined.title': `Write a Thank You Message`,
   'tabs.audit.rules.smart_form.congrats_url_invalid.description': `To continue, please enter a valid URL where your customers will be redirected after completing the Form.`,

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -660,6 +660,8 @@ export const messages_es = {
   'tabs.audit.rules.payu_button.empty_links.title': `Los enlaces de solicitud de pago en los botones de pago PayU están vacíos`,
   'tabs.audit.rules.promo_code.id_undefined.description': `Las automatizaciones necesitan que se encuentre correctamente configurado el código dinámico`,
   'tabs.audit.rules.promo_code.id_undefined.title': `El código de promoción dinámico requiere configurarse.`,
+  'tabs.audit.rules.roulette.wheel_list_incomplete.description': `Para continuar debe completar los datos de las casillas`,
+  'tabs.audit.rules.roulette.wheel_list_incomplete.title': `Ruleta incompleta`,
   'tabs.audit.rules.smart_form.congrats_message_undefined.description': `Para continuar, debes elaborar un Mensaje de Agradecimiento, que verán tus clientes al completar el Formulario.`,
   'tabs.audit.rules.smart_form.congrats_message_undefined.title': `Redacta un Mensaje de Agradecimiento`,
   'tabs.audit.rules.smart_form.congrats_url_invalid.description': `Para continuar, ingresa una URL válida hacia donde se redireccionará a tus clientes al completar el Formulario.`,


### PR DESCRIPTION
fix: add incomplete slide check for roulette widget

![Capture](https://github.com/user-attachments/assets/ea8d22fe-2880-4b7b-9c5b-2e0d62624376)

TODO: 

- update final content
- add at doppler-popuphub-frontend project audit rule for ROULETTE (hasUnlayerError)

![image](https://github.com/user-attachments/assets/6547517f-0eae-4884-a079-2f96aa3509c4)

