### PR TITLE
Fix copy icon

### DIFF
--- a/src/customJs/tools/wheel/wheelFortuneViewer.tsx
+++ b/src/customJs/tools/wheel/wheelFortuneViewer.tsx
@@ -116,12 +116,13 @@ export const WheelFortuneViewer: ViewerComponent<any> = (rest) => {
   } as const;
 
   const giftCodeStyle = {
-    display: 'flex',
-    textAlign: 'center',
+    display: 'inline-block',
     fontSize: '18px',
     fontFamily: 'inherit',
     fontWeight: '900',
     color: '#000',
+    textAlign: 'center',
+    width: '100%',
   } as const;
 
   const slides = values.wheelList;
@@ -296,14 +297,17 @@ export const WheelFortuneViewer: ViewerComponent<any> = (rest) => {
               backgroundColor: '#fff',
               margin: '10px',
               padding: '10px',
+              gap: '10px',
             }}
           >
-            <span style={giftCodeStyle}>[[GIFT CODE]]</span>
+            <span style={giftCodeStyle}>
+              [[GIFT CODE]]
+            </span>
             <i
               className="dp-roulette-congrats-copy-icon"
               style={{
                 display: 'flex',
-                position: 'relative',
+                flexShrink: 0,
                 cursor: 'pointer',
               }}
             >

--- a/src/customJs/tools/wheel/wheelFortuneViewer.tsx
+++ b/src/customJs/tools/wheel/wheelFortuneViewer.tsx
@@ -123,6 +123,7 @@ export const WheelFortuneViewer: ViewerComponent<any> = (rest) => {
     color: '#000',
     textAlign: 'center',
     width: '100%',
+    wordBreak: 'break-word',
   } as const;
 
   const slides = values.wheelList;

--- a/src/customJs/tools/wheel/wheelFortuneViewer.tsx
+++ b/src/customJs/tools/wheel/wheelFortuneViewer.tsx
@@ -301,9 +301,7 @@ export const WheelFortuneViewer: ViewerComponent<any> = (rest) => {
               gap: '10px',
             }}
           >
-            <span style={giftCodeStyle}>
-              [[GIFT CODE]]
-            </span>
+            <span style={giftCodeStyle}>[[GIFT CODE]]</span>
             <i
               className="dp-roulette-congrats-copy-icon"
               style={{


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d3bacef9-b00d-4123-b677-671ba4a4f4f1)

With these style changes, we can accommodate long promo codes.