### PR TITLE
Se muestra campo infohtml en productos normales

### DIFF
--- a/src/customJs/tools/product/ProductViewer.tsx
+++ b/src/customJs/tools/product/ProductViewer.tsx
@@ -123,7 +123,7 @@ export const ProductViewer: ViewerComponent<
   const image =
     values.image?.url || `${ASSETS_BASE_URL}/product_transparent.svg`;
 
-  let productToolElement = {
+  const productToolElement = {
     product: {
       url: {
         value: values.productUrl ? values.productUrl : '#',

--- a/src/customJs/tools/product/ProductViewer.tsx
+++ b/src/customJs/tools/product/ProductViewer.tsx
@@ -123,7 +123,7 @@ export const ProductViewer: ViewerComponent<
   const image =
     values.image?.url || `${ASSETS_BASE_URL}/product_transparent.svg`;
 
-  const productToolElement = {
+  let productToolElement = {
     product: {
       url: {
         value: values.productUrl ? values.productUrl : '#',
@@ -175,12 +175,15 @@ export const ProductViewer: ViewerComponent<
       value: values.buttonText,
       style: buttonStyle,
     },
-    info: {
-      value: 'infoHtml' in values ? values.infoHtml : '',
-      isDynamic: 'infoIsDynamic' in values ? values.infoIsDynamic : '',
-      style: infoStyle,
-    },
   };
+
+  if ('infoIsDynamic' in values) {
+    (productToolElement as any).info = {
+      value: 'infoHtml' in values ? values.infoHtml : '',
+      isDynamic: 'infoIsDynamic' in values ? values.infoIsDynamic : false,
+      style: infoStyle,
+    };
+  }
 
   const getLayout = () => {
     switch (values.arrangement) {

--- a/src/customJs/tools/product/ProductViewer.tsx
+++ b/src/customJs/tools/product/ProductViewer.tsx
@@ -180,7 +180,7 @@ export const ProductViewer: ViewerComponent<
   if ('infoIsDynamic' in values) {
     (productToolElement as any).info = {
       value: 'infoHtml' in values ? values.infoHtml : '',
-      isDynamic: 'infoIsDynamic' in values ? values.infoIsDynamic : false,
+      isDynamic: values.infoIsDynamic,
       style: infoStyle,
     };
   }

--- a/src/customJs/tools/product/layout/layoutPosition01.tsx
+++ b/src/customJs/tools/product/layout/layoutPosition01.tsx
@@ -29,7 +29,7 @@ export const ProductLayoutViewer01 = ({ values }: { values: any }) => {
         />
         <span
           style={values.info.style}
-          dangerouslySetInnerHTML={{ __html: values.info.value }}
+          dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
           {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
         />
         <span style={values.prices.style} data-testid="prices-container">

--- a/src/customJs/tools/product/layout/layoutPosition01.tsx
+++ b/src/customJs/tools/product/layout/layoutPosition01.tsx
@@ -27,11 +27,13 @@ export const ProductLayoutViewer01 = ({ values }: { values: any }) => {
             'data-dc-type': 'DC:DESCRIPTION',
           })}
         />
-        <span
-          style={values.info.style}
-          dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
-          {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
-        />
+        {values.info && (
+          <span
+            style={values.info.style}
+            dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
+            {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
+          />
+        )}
         <span style={values.prices.style} data-testid="prices-container">
           <span
             style={values.prices.default.style}

--- a/src/customJs/tools/product/layout/layoutPosition02.tsx
+++ b/src/customJs/tools/product/layout/layoutPosition02.tsx
@@ -23,11 +23,13 @@ export const ProductLayoutViewer02 = ({ values }: { values: any }) => {
             'data-dc-type': 'DC:DESCRIPTION',
           })}
         />
-        <span
-          style={values.info.style}
-          dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
-          {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
-        />
+        {values.info && (
+          <span
+            style={values.info.style}
+            dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
+            {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
+          />
+        )}
         <span style={values.prices.style} data-testid="prices-container">
           <span
             style={values.prices.default.style}

--- a/src/customJs/tools/product/layout/layoutPosition02.tsx
+++ b/src/customJs/tools/product/layout/layoutPosition02.tsx
@@ -25,7 +25,7 @@ export const ProductLayoutViewer02 = ({ values }: { values: any }) => {
         />
         <span
           style={values.info.style}
-          dangerouslySetInnerHTML={{ __html: values.info.value }}
+          dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
           {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
         />
         <span style={values.prices.style} data-testid="prices-container">

--- a/src/customJs/tools/product/layout/layoutPosition03.tsx
+++ b/src/customJs/tools/product/layout/layoutPosition03.tsx
@@ -34,11 +34,13 @@ export const ProductLayoutViewer03 = ({ values }: { values: any }) => {
             'data-dc-type': 'DC:DESCRIPTION',
           })}
         />
-        <span
-          style={values.info.style}
-          dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
-          {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
-        />
+        {values.info && (
+          <span
+            style={values.info.style}
+            dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
+            {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
+          />
+        )}
         <span
           style={values.discount.style}
           {...(values.discount.isDynamic && { 'data-dc-type': 'DC:DISCOUNT' })}

--- a/src/customJs/tools/product/layout/layoutPosition03.tsx
+++ b/src/customJs/tools/product/layout/layoutPosition03.tsx
@@ -36,7 +36,7 @@ export const ProductLayoutViewer03 = ({ values }: { values: any }) => {
         />
         <span
           style={values.info.style}
-          dangerouslySetInnerHTML={{ __html: values.info.value }}
+          dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
           {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
         />
         <span

--- a/src/customJs/tools/product/layout/layoutPosition04.tsx
+++ b/src/customJs/tools/product/layout/layoutPosition04.tsx
@@ -53,11 +53,13 @@ export const ProductLayoutViewer04 = ({ values }: { values: any }) => {
             'data-dc-type': 'DC:DESCRIPTION',
           })}
         />
-        <span
-          style={values.info.style}
-          dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
-          {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
-        />
+        {values.info && (
+          <span
+            style={values.info.style}
+            dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
+            {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
+          />
+        )}
         <span
           style={values.discount.style}
           {...(values.discount.isDynamic && { 'data-dc-type': 'DC:DISCOUNT' })}

--- a/src/customJs/tools/product/layout/layoutPosition04.tsx
+++ b/src/customJs/tools/product/layout/layoutPosition04.tsx
@@ -55,7 +55,7 @@ export const ProductLayoutViewer04 = ({ values }: { values: any }) => {
         />
         <span
           style={values.info.style}
-          dangerouslySetInnerHTML={{ __html: values.info.value }}
+          dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
           {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
         />
         <span

--- a/src/customJs/tools/product/layout/layoutPosition05.tsx
+++ b/src/customJs/tools/product/layout/layoutPosition05.tsx
@@ -90,11 +90,13 @@ export const ProductLayoutViewer05 = ({ values }: { values: any }) => {
             'data-dc-type': 'DC:DESCRIPTION',
           })}
         />
-        <span
-          style={values.info.style}
-          dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
-          {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
-        />
+        {values.info && (
+          <span
+            style={values.info.style}
+            dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
+            {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
+          />
+        )}
         <span
           style={values.discount.style}
           {...(values.discount.isDynamic && { 'data-dc-type': 'DC:DISCOUNT' })}

--- a/src/customJs/tools/product/layout/layoutPosition05.tsx
+++ b/src/customJs/tools/product/layout/layoutPosition05.tsx
@@ -92,7 +92,7 @@ export const ProductLayoutViewer05 = ({ values }: { values: any }) => {
         />
         <span
           style={values.info.style}
-          dangerouslySetInnerHTML={{ __html: values.info.value }}
+          dangerouslySetInnerHTML={{ __html: values.info.value ?? '' }}
           {...(values.info.isDynamic && { 'data-dc-type': 'DC:INFO' })}
         />
         <span


### PR DESCRIPTION
Si ```infoIsDynamic``` no esta presente en values directamente no se agrega el objeto en el ```ProductViewer```. Se estaba agregando de igual forma incluso cuando el producto no era dinámico, no siguiendo la idea planteada en el index.ts de producto donde para agregar info a las options usamos la condicion ```if (isProductTypeDynamic)```.

De esta forma evitamos que intente imprimir valores nulos y se dejara de mostrar ```null``` en productos que **NO** son dinámicos.