### PR TITLE
Agregar clase dp-click-button a botones

### DIFF
--- a/src/customJs/tools/wheel/wheelFortuneViewer.tsx
+++ b/src/customJs/tools/wheel/wheelFortuneViewer.tsx
@@ -303,7 +303,7 @@ export const WheelFortuneViewer: ViewerComponent<any> = (rest) => {
           >
             <span style={giftCodeStyle}>[[GIFT CODE]]</span>
             <i
-              className="dp-roulette-congrats-copy-icon"
+              className="dp-roulette-congrats-copy-icon dp-click-button"
               style={{
                 display: 'flex',
                 flexShrink: 0,
@@ -329,7 +329,11 @@ export const WheelFortuneViewer: ViewerComponent<any> = (rest) => {
             </i>
           </div>
           <div style={{ display: 'flex' }}>
-            <button type="button" style={congratysBtnStyle}>
+            <button
+              type="button"
+              className="dp-click-button"
+              style={congratysBtnStyle}
+            >
               {values.congratsButtonText}
             </button>
           </div>

--- a/src/customJs/tools/wheel/wheelFortuneViewer.tsx
+++ b/src/customJs/tools/wheel/wheelFortuneViewer.tsx
@@ -303,7 +303,7 @@ export const WheelFortuneViewer: ViewerComponent<any> = (rest) => {
           >
             <span style={giftCodeStyle}>[[GIFT CODE]]</span>
             <i
-              className="dp-roulette-congrats-copy-icon dp-click-buttons"
+              className="dp-roulette-congrats-copy-icon dp-click-button"
               style={{
                 display: 'flex',
                 flexShrink: 0,

--- a/src/customJs/tools/wheel/wheelFortuneViewer.tsx
+++ b/src/customJs/tools/wheel/wheelFortuneViewer.tsx
@@ -303,7 +303,7 @@ export const WheelFortuneViewer: ViewerComponent<any> = (rest) => {
           >
             <span style={giftCodeStyle}>[[GIFT CODE]]</span>
             <i
-              className="dp-roulette-congrats-copy-icon dp-click-button"
+              className="dp-roulette-congrats-copy-icon dp-click-buttons"
               style={{
                 display: 'flex',
                 flexShrink: 0,


### PR DESCRIPTION
Se agrega la clase ```dp-click-button``` al boton e icono de copiar del widget de ruleta.