### PR TITLE
[DOI-2364] Fix: component icon

### DIFF
--- a/src/customJs/tools/promotional/index.ts
+++ b/src/customJs/tools/promotional/index.ts
@@ -68,7 +68,7 @@ export const getPromotionalToolDefinition: () =>
   return {
     name: 'promotional',
     label: $t('_dp.promotional.label'),
-    icon: `${ASSETS_BASE_URL}/promotion_code_audit1.svg`,
+    icon: `${ASSETS_BASE_URL}/promotion_code_v2.svg`,
     usageLimit: 1,
     Component: PromotionalViewer,
     values: {


### PR DESCRIPTION
Se utiliza un icono más grande para el boton del componente.

<img width="394" height="316" alt="image" src="https://github.com/user-attachments/assets/01629c90-b03b-4733-8671-521db08badac" />
