### PR TITLE
[DOI-2897] Fix Roulette width container

### DIFF
--- a/src/customJs/tools/smartforms/smartFormViewer.tsx
+++ b/src/customJs/tools/smartforms/smartFormViewer.tsx
@@ -2,7 +2,7 @@ import { React } from '../../unlayer-react';
 import { ViewerComponent } from '../../types';
 import { UnlayerField } from './types';
 
-export const SmartFormViewer: ViewerComponent<any> = ({ values, isViewer }) => {
+export const SmartFormViewer: ViewerComponent<any> = ({ values }) => {
   const formSectionStyle = {
     display: 'block',
     textAlign: values.formAlign,
@@ -197,17 +197,8 @@ export const SmartFormViewer: ViewerComponent<any> = ({ values, isViewer }) => {
     }
   };
 
-  const viewerOnlyCss = isViewer
-    ? `
-      .u-popup-content {
-        overflow-x: hidden !important;
-      }
-    `
-    : '';
-
   return (
     <div>
-      <style>{viewerOnlyCss}</style>
       <section style={formSectionStyle} role="container">
         <form
           id="dp_sf"

--- a/src/customJs/tools/wheel/wheelFortuneViewer.tsx
+++ b/src/customJs/tools/wheel/wheelFortuneViewer.tsx
@@ -247,6 +247,7 @@ export const WheelFortuneViewer: ViewerComponent<any> = (rest) => {
         style={{
           backgroundColor: values.wheelBackgroudColor,
           borderRadius: '10px',
+          width: '100%',
         }}
       >
         <section style={wheelContainerStyle} className="dp-wheel-roulette">


### PR DESCRIPTION
The roulette widget wasn’t filling the entire pop-up container. Setting its width to 100% fixes the issue.

I also reverted a change from a previous PR that added overflow-x: hidden; to smart forms, since it was breaking the display of other widgets.