### PR TITLE
[DOI-2927] Align final message editor text color with preview

### DIFF
--- a/src/customJs/tools/promotional/index.ts
+++ b/src/customJs/tools/promotional/index.ts
@@ -29,8 +29,8 @@ const DEFAULT_INIT_DESCRIPTION = `
 
 const DEFAULT_END_DESCRIPTION = `
   <p style="text-align: center; margin: 0 0 6px; line-height: 1.15;"><span style="color: rgb(254, 230, 0); font-size: 28px;"><strong><span style="font-family: 'Open Sans', sans-serif;">&iexcl;El descuento es tuyo!</span></strong></span></p>
-  <p style="text-align: center; margin: 0; line-height: 1.35;"><span style="font-size: 16px; font-weight: 400; font-family: 'Open Sans', sans-serif;">Copia el siguiente c&oacute;digo de descuento </span></p>
-  <p style="text-align: center; margin: 0; line-height: 1.35;"><span style="font-size: 16px; font-weight: 400; font-family: 'Open Sans', sans-serif;">y &uacute;salo en tu pr&oacute;xima compra.<br><br></span></p>`;
+  <p style="text-align: center; margin: 0; line-height: 1.35;"><span style="font-size: 16px; font-weight: 400; font-family: 'Open Sans', sans-serif; color: rgb(255, 255, 255);">Copia el siguiente c&oacute;digo de descuento </span></p>
+  <p style="text-align: center; margin: 0; line-height: 1.35;"><span style="font-size: 16px; font-weight: 400; font-family: 'Open Sans', sans-serif; color: rgb(255, 255, 255);">y &uacute;salo en tu pr&oacute;xima compra.<br><br></span></p>`;
 
 const DEFAULT_BUTTON_BORDER: Border = {
   borderTopWidth: '2px',


### PR DESCRIPTION
Se corrigió una inconsistencia visual en el widget promocional entre el editor y la preview del mensaje final. En código, se actualizó el DEFAULT_END_DESCRIPTION del tool promotional para que el texto secundario del mensaje final defina color: rgb(255, 255, 255) de forma explícita, igual que ya ocurría en el mensaje inicial. Con esto, el contenido mostrado en el textbox del editor queda alineado con lo que se renderiza en la preview.

Además, se actualizó el widgetType persistido para reflejar el mismo ajuste en `congratsHtml`, agregando el color blanco en los spans de los párrafos descriptivos del mensaje final.