### PR TITLE
[DOI-2928] Do not allow delete email field

### DIFF
--- a/src/customJs/tools/promotional/index.ts
+++ b/src/customJs/tools/promotional/index.ts
@@ -11,7 +11,10 @@ import {
   richTextProperty,
   textProperty,
 } from '../../properties/helpers';
-import { availableFields, updateFieldsWidgetModal } from '../smartforms/helper';
+import {
+  applyFieldsWidgetModalRestrictions,
+  availableFields,
+} from '../smartforms/helper';
 import { subscriptionListProperty } from '../../properties/subscription_list';
 import { buttonGroupProperty } from '../../properties/button_group';
 import { labeledAutoWidthProperty } from '../../properties/labeled_auto_width';
@@ -70,7 +73,11 @@ export const getPromotionalToolDefinition: () =>
     label: $t('_dp.promotional.label'),
     icon: `${ASSETS_BASE_URL}/promotion_code_v2.svg`,
     usageLimit: 1,
-    modalUpdate: addEventListener('click', updateFieldsWidgetModal, true),
+    modalUpdate: addEventListener(
+      'click',
+      applyFieldsWidgetModalRestrictions,
+      true,
+    ),
     Component: PromotionalViewer,
     values: {
       containerPadding: '0px',

--- a/src/customJs/tools/promotional/index.ts
+++ b/src/customJs/tools/promotional/index.ts
@@ -11,7 +11,7 @@ import {
   richTextProperty,
   textProperty,
 } from '../../properties/helpers';
-import { availableFields } from '../smartforms/helper';
+import { availableFields, updateFieldsWidgetModal } from '../smartforms/helper';
 import { subscriptionListProperty } from '../../properties/subscription_list';
 import { buttonGroupProperty } from '../../properties/button_group';
 import { labeledAutoWidthProperty } from '../../properties/labeled_auto_width';
@@ -70,6 +70,7 @@ export const getPromotionalToolDefinition: () =>
     label: $t('_dp.promotional.label'),
     icon: `${ASSETS_BASE_URL}/promotion_code_v2.svg`,
     usageLimit: 1,
+    modalUpdate: addEventListener('click', updateFieldsWidgetModal, true),
     Component: PromotionalViewer,
     values: {
       containerPadding: '0px',

--- a/src/customJs/tools/smartforms/helper.ts
+++ b/src/customJs/tools/smartforms/helper.ts
@@ -1,7 +1,7 @@
 import { $t } from '../../localization';
 import { dropdownProperty } from '../../properties/helpers';
 import { UnlayerProperty } from '../../types';
-import { CustomField, SmartFormAction } from './types';
+import { CustomField, SmartFormAction, UnlayerField } from './types';
 
 export const behaviorListProperty: () => UnlayerProperty<string> = () =>
   dropdownProperty({
@@ -89,4 +89,55 @@ export const isValidUrl = (url: string) => {
     /^(http(s):\/\/.)[-a-zA-Z0-9@:%._\+~#=]{0,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/g,
   );
   return URL_VALID_REGEX.test(url);
+};
+
+export const updateFieldsWidgetModal = (event: any) => {
+  if (event.target.className != 'col-12') {
+    return;
+  }
+
+  const modalBody = document.querySelectorAll(
+    '.blockbuilder-fields-widget-modal > div > div ',
+  )[1] as HTMLElement | undefined;
+  if (!modalBody) {
+    return;
+  }
+
+  const modalfooter = document.querySelectorAll(
+    '.blockbuilder-fields-widget-modal > div > div ',
+  )[2] as HTMLElement | undefined;
+  if (!modalfooter) {
+    return;
+  }
+
+  const forms = modalBody.getElementsByTagName('form');
+  const inputs = modalBody.getElementsByTagName('input');
+  const inputName = inputs[0]?.value;
+  const currentField = availableFields.find((field: UnlayerField) => {
+    return field.name == inputName;
+  });
+
+  if (!currentField) {
+    return;
+  }
+
+  // disabled change type update
+  const buttonType = modalBody.getElementsByTagName('button')[0];
+  if (buttonType) {
+    buttonType['disabled'] = currentField.type !== 'text';
+  }
+
+  // disabled dropdown values update
+  const inputOption = modalBody.getElementsByTagName('textarea')[0];
+  if (inputOption) {
+    inputOption['disabled'] = currentField.type !== 'text';
+  }
+
+  const buttonEliminate = modalfooter.getElementsByTagName('button')[1];
+  if (buttonEliminate) {
+    buttonEliminate['disabled'] = inputName === 'EMAIL';
+  }
+
+  // remove name fieldset
+  forms[0]?.remove();
 };

--- a/src/customJs/tools/smartforms/helper.ts
+++ b/src/customJs/tools/smartforms/helper.ts
@@ -91,7 +91,7 @@ export const isValidUrl = (url: string) => {
   return URL_VALID_REGEX.test(url);
 };
 
-export const updateFieldsWidgetModal = (event: any) => {
+export const applyFieldsWidgetModalRestrictions = (event: any) => {
   if (event.target.className != 'col-12') {
     return;
   }

--- a/src/customJs/tools/smartforms/helper.ts
+++ b/src/customJs/tools/smartforms/helper.ts
@@ -69,19 +69,20 @@ const optionToString = (options: string[] | undefined) => {
     ?.slice(0, -1);
 };
 
-export const availableFields = userData.fields?.map((field: CustomField) => {
-  return {
-    meta_data: {
-      ...field,
-    },
-    name: field.name,
-    type: getFieldCompatibleType(field.type),
-    label: field.name,
-    required: field.required,
-    show_label: true,
-    options: optionToString(field.allowedValues),
-  };
-});
+export const availableFields: UnlayerField[] =
+  userData.fields?.map((field: CustomField) => {
+    return {
+      meta_data: {
+        ...field,
+      },
+      name: field.name,
+      type: getFieldCompatibleType(field.type),
+      label: field.name,
+      required: field.required,
+      show_label: true,
+      options: optionToString(field.allowedValues),
+    };
+  }) ?? [];
 
 export const isValidUrl = (url: string) => {
   /* eslint-disable no-useless-escape */

--- a/src/customJs/tools/smartforms/helper.ts
+++ b/src/customJs/tools/smartforms/helper.ts
@@ -92,53 +92,52 @@ export const isValidUrl = (url: string) => {
   return URL_VALID_REGEX.test(url);
 };
 
-export const applyFieldsWidgetModalRestrictions = (event: any) => {
-  if (event.target.className != 'col-12') {
-    return;
-  }
+export const applyFieldsWidgetModalRestrictions = () => {
+  window.requestAnimationFrame(() => {
+    const modal = document.querySelector('.blockbuilder-fields-widget-modal');
+    if (!(modal instanceof HTMLElement)) {
+      return;
+    }
 
-  const modalBody = document.querySelectorAll(
-    '.blockbuilder-fields-widget-modal > div > div ',
-  )[1] as HTMLElement | undefined;
-  if (!modalBody) {
-    return;
-  }
+    const modalBody = modal.querySelector('.modal-content');
+    const modalFooter = modal.querySelector('.modal-footer');
+    if (
+      !(modalBody instanceof HTMLElement) ||
+      !(modalFooter instanceof HTMLElement)
+    ) {
+      return;
+    }
 
-  const modalfooter = document.querySelectorAll(
-    '.blockbuilder-fields-widget-modal > div > div ',
-  )[2] as HTMLElement | undefined;
-  if (!modalfooter) {
-    return;
-  }
+    const typeButton = modalBody.querySelector('button.dropdown-button');
+    const fieldNameInput = modalBody.querySelector('input[name="name"]');
+    const inputOption = modalBody.querySelector('textarea');
+    const fieldName =
+      fieldNameInput instanceof HTMLInputElement
+        ? fieldNameInput.value
+        : undefined;
+    const currentField = availableFields.find(
+      (field: UnlayerField) => field.name === fieldName,
+    );
 
-  const forms = modalBody.getElementsByTagName('form');
-  const inputs = modalBody.getElementsByTagName('input');
-  const inputName = inputs[0]?.value;
-  const currentField = availableFields.find((field: UnlayerField) => {
-    return field.name == inputName;
+    if (typeButton instanceof HTMLButtonElement && currentField) {
+      typeButton.disabled = currentField.type !== 'text';
+    }
+
+    if (inputOption instanceof HTMLTextAreaElement && currentField) {
+      inputOption.disabled = currentField.type !== 'text';
+    }
+
+    const footerButtons = modalFooter.querySelectorAll('button');
+    const buttonEliminate = footerButtons[1];
+    if (
+      buttonEliminate instanceof HTMLButtonElement &&
+      fieldNameInput instanceof HTMLInputElement
+    ) {
+      buttonEliminate.disabled = fieldNameInput.value === 'EMAIL';
+    }
+
+    if (fieldNameInput instanceof HTMLInputElement) {
+      fieldNameInput.closest('form')?.remove();
+    }
   });
-
-  if (!currentField) {
-    return;
-  }
-
-  // disabled change type update
-  const buttonType = modalBody.getElementsByTagName('button')[0];
-  if (buttonType) {
-    buttonType['disabled'] = currentField.type !== 'text';
-  }
-
-  // disabled dropdown values update
-  const inputOption = modalBody.getElementsByTagName('textarea')[0];
-  if (inputOption) {
-    inputOption['disabled'] = currentField.type !== 'text';
-  }
-
-  const buttonEliminate = modalfooter.getElementsByTagName('button')[1];
-  if (buttonEliminate) {
-    buttonEliminate['disabled'] = inputName === 'EMAIL';
-  }
-
-  // remove name fieldset
-  forms[0]?.remove();
 };

--- a/src/customJs/tools/smartforms/index.ts
+++ b/src/customJs/tools/smartforms/index.ts
@@ -14,11 +14,11 @@ import {
   richTextProperty,
 } from '../../properties/helpers';
 import {
+  applyFieldsWidgetModalRestrictions,
   behaviorListProperty,
   congratsBehaviorListProperty,
   availableFields,
   isValidUrl,
-  updateFieldsWidgetModal,
 } from './helper';
 import { urlProperty } from '../../properties/url';
 import { subscriptionListProperty } from '../../properties/subscription_list';
@@ -33,7 +33,11 @@ export const getSmartFormToolDefinition: () =>
     label: $t('_dp.smart_forms.label'),
     icon: `${ASSETS_BASE_URL}/form1.svg`,
     usageLimit: 1,
-    modalUpdate: addEventListener('click', updateFieldsWidgetModal, true),
+    modalUpdate: addEventListener(
+      'click',
+      applyFieldsWidgetModalRestrictions,
+      true,
+    ),
     Component: SmartFormViewer,
     options: {
       behavior: {

--- a/src/customJs/tools/smartforms/index.ts
+++ b/src/customJs/tools/smartforms/index.ts
@@ -1,7 +1,7 @@
 import { $t } from '../../localization';
 import { SmartFormViewer } from './smartFormViewer';
 import { ReactToolDefinitionFrom } from '../../types';
-import { SmartFormBase, SmartFormValues, UnlayerField } from './types';
+import { SmartFormBase, SmartFormValues } from './types';
 import { ASSETS_BASE_URL } from '../../constants';
 import {
   alignmentProperty,
@@ -18,6 +18,7 @@ import {
   congratsBehaviorListProperty,
   availableFields,
   isValidUrl,
+  updateFieldsWidgetModal,
 } from './helper';
 import { urlProperty } from '../../properties/url';
 import { subscriptionListProperty } from '../../properties/subscription_list';
@@ -32,7 +33,7 @@ export const getSmartFormToolDefinition: () =>
     label: $t('_dp.smart_forms.label'),
     icon: `${ASSETS_BASE_URL}/form1.svg`,
     usageLimit: 1,
-    modalUpdate: addEventListener('click', getClick, true),
+    modalUpdate: addEventListener('click', updateFieldsWidgetModal, true),
     Component: SmartFormViewer,
     options: {
       behavior: {
@@ -299,39 +300,4 @@ export const getSmartFormToolDefinition: () =>
       return defaultErrors;
     },
   };
-};
-
-/* Note: temporal function for manipulating UNLAYER field edit modal */
-const getClick = (event: any) => {
-  if (event.target.className == 'col-12') {
-    const modalBody = document.querySelectorAll(
-      '.blockbuilder-fields-widget-modal > div > div ',
-    )[1];
-    if (!modalBody) {
-      return;
-    }
-    const modalfooter = document.querySelectorAll(
-      '.blockbuilder-fields-widget-modal > div > div ',
-    )[2];
-    const forms = modalBody.getElementsByTagName('form');
-    const inputs = modalBody.getElementsByTagName('input');
-    const inputName = inputs[0].value;
-    const currentField = availableFields.find((field: UnlayerField) => {
-      return field.name == inputName;
-    });
-
-    //disabled change type update
-    const buttonType = modalBody.getElementsByTagName('button')[0];
-    buttonType['disabled'] = currentField.type !== 'text';
-
-    //disabled dropdown values update
-    const inputOption = modalBody.getElementsByTagName('textarea')[0];
-    if (inputOption) inputOption['disabled'] = currentField.type !== 'text';
-
-    const buttonEliminate = modalfooter.getElementsByTagName('button')[1];
-    buttonEliminate['disabled'] = inputName === 'EMAIL';
-
-    //remove name fieldset
-    forms[0].remove();
-  }
 };

--- a/src/customJs/tools/wheel/index.ts
+++ b/src/customJs/tools/wheel/index.ts
@@ -8,7 +8,7 @@ import {
 } from '../../properties/helpers';
 import { subscriptionListProperty } from '../../properties/subscription_list';
 import { wheelListProperty } from '../../properties/wheel_list';
-import { availableFields } from '../smartforms/helper';
+import { availableFields, updateFieldsWidgetModal } from '../smartforms/helper';
 import { WheelFortuneValues, WheelSlice } from './types';
 import { buttonGroupProperty } from '../../properties/button_group';
 
@@ -71,6 +71,7 @@ export const getWheelFortuneToolDefinition: () =>
     label: $t('_dp.wheel_fortune.label'),
     icon: `${ASSETS_BASE_URL}/roulette2.svg`,
     usageLimit: 1,
+    modalUpdate: addEventListener('click', updateFieldsWidgetModal, true),
 
     Component: WheelFortuneViewer,
     options: {

--- a/src/customJs/tools/wheel/index.ts
+++ b/src/customJs/tools/wheel/index.ts
@@ -8,7 +8,10 @@ import {
 } from '../../properties/helpers';
 import { subscriptionListProperty } from '../../properties/subscription_list';
 import { wheelListProperty } from '../../properties/wheel_list';
-import { availableFields, updateFieldsWidgetModal } from '../smartforms/helper';
+import {
+  applyFieldsWidgetModalRestrictions,
+  availableFields,
+} from '../smartforms/helper';
 import { WheelFortuneValues, WheelSlice } from './types';
 import { buttonGroupProperty } from '../../properties/button_group';
 
@@ -71,7 +74,11 @@ export const getWheelFortuneToolDefinition: () =>
     label: $t('_dp.wheel_fortune.label'),
     icon: `${ASSETS_BASE_URL}/roulette2.svg`,
     usageLimit: 1,
-    modalUpdate: addEventListener('click', updateFieldsWidgetModal, true),
+    modalUpdate: addEventListener(
+      'click',
+      applyFieldsWidgetModalRestrictions,
+      true,
+    ),
 
     Component: WheelFortuneViewer,
     options: {


### PR DESCRIPTION
Este PR actualiza el comportamiento del editor de campos para los widgets que usan el modal compartido de `fields`, de forma que el campo `Email` no pueda eliminarse de manera consistente.

- Se agregó la lógica compartida de restricciones del modal en `smartforms/helper.ts`
- Esa lógica compartida ahora se reutiliza desde:
  - `smartforms/index.ts`
  - `wheel/index.ts`
  - `promotional/index.ts`
- Se asegura que el botón `Eliminar` quede deshabilitado cuando el campo seleccionado es `EMAIL`

Antes de este cambio, la eliminación del campo Email estaba bloqueada en Smart Form, y en Roulette ese comportamiento se heredaba porque `smartForm` también estaba habilitado en la configuración del widget. En cambio, Promotional no registraba esa misma lógica del modal, por lo que el campo Email todavía podía eliminarse.

Con este cambio, cada tool que usa el modal compartido de `fields` aplica explícitamente las mismas restricciones, sin depender de que Smart Form esté habilitado dentro de la misma configuración del editor.

El cambio ya esta INT y puede probarse.