### PR TITLE
[NO-TICKET] Align roulette congrats button sizing with editor form button

### DIFF
--- a/src/customJs/tools/wheel/wheelFortuneViewer.tsx
+++ b/src/customJs/tools/wheel/wheelFortuneViewer.tsx
@@ -163,6 +163,7 @@ export const WheelFortuneViewer: ViewerComponent<any> = (rest) => {
   const congratysBtnStyle = {
     border: 'none',
     borderRadius: formRest.values.buttonBorderRadius,
+    boxSizing: 'border-box',
     display: 'inline-block',
     textAlign: formRest.values.buttonAlign,
     overflow: 'hidden',


### PR DESCRIPTION
Como se puede ver el boton de copiado es mas grande en el canvas de unlayer:

<img width="1919" height="858" alt="image" src="https://github.com/user-attachments/assets/a07d9fc1-33a3-4524-ab17-1a4fa55d1516" />

----

Este PR agrega boxSizing: 'border-box' al botón Copiar código de la vista final de la ruleta dentro de WheelFortuneViewer.

box-sizing: border-box hace que el navegador calcule el tamaño final del elemento incluyendo el padding y el border dentro del width y height definidos. Sin esta regla, el modelo por defecto (content-box) suma el padding por fuera de esas dimensiones, lo que puede hacer que el botón termine viéndose más grande de lo esperado.

En este caso, el cambio busca estabilizar el cálculo del tamaño del botón dentro del canvas del editor de Unlayer, evitando que se renderice con una altura visual mayor que la esperada.

No se modificó el widget type
