### PR TITLE
fix(unlayer): inline custom assets for local editor integration

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,7 @@
 INLINE_RUNTIME_CHUNK=false
 PUBLIC_URL=http://localhost:3000
+# Optional: disable inline mode and force loading custom assets by URL.
+# REACT_APP_UNLAYER_INLINE_CUSTOM_ASSETS=false
 REACT_APP_PROJECT_ID=32092
 REACT_APP_USER_ID=1234
 # COMPLETE REACT_APP_USER_SIGNATURE IN .env.development.local BASED ON DOPPLER BEHAVIOR

--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ You will also see any lint errors in the console.
 
 **Note:** For local run, make sure to set Unlayer Account data (`PROJECT_ID`, `USERID`, `USER_SIGNATURE`) in `.env.development.local`
 
+#### Local customJS/customCSS with Unlayer (`editor.unlayer.com`)
+
+If Unlayer blocks `http://localhost:3000/customJs/*` with a loopback/CORS error, it is due to browser Private Network Access rules for public origins (`https://editor.unlayer.com`) calling local addresses.
+
+Default strategy (recommended):
+
+- Inline mode: the app fetches `customJs/main.css` and `customJs/index.js` from its own origin and injects them as source code into Unlayer, avoiding iframe calls to loopback.
+
+Only if you explicitly need URL mode, disable inline mode:
+
+```env
+REACT_APP_UNLAYER_INLINE_CUSTOM_ASSETS=false
+```
+
 #### `yarn test`
 
 Launches the test runner in the interactive watch mode.\

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import mergeTags from './external/merge.tags';
 import styled from 'styled-components';
 import { ASSETS_BASE_URL } from './customJs/constants';
@@ -36,6 +36,77 @@ const Bar = styled.div`
 
 const App: React.FC = () => {
   const emailEditorRef = useRef<EditorRef>(null);
+  const shouldInlineCustomAssets =
+    process.env.REACT_APP_UNLAYER_INLINE_CUSTOM_ASSETS !== 'false';
+  const [customCssSource, setCustomCssSource] = useState<string | null>(null);
+  const [customJsSource, setCustomJsSource] = useState<string | null>(null);
+  const unlayerAssetsBaseUrl = (
+    process.env.REACT_APP_UNLAYER_ASSETS_URL ||
+    window.location.origin ||
+    process.env.PUBLIC_URL ||
+    ''
+  ).replace(/\/$/, '');
+
+  useEffect(() => {
+    if (!shouldInlineCustomAssets) {
+      return;
+    }
+
+    let canceled = false;
+
+    const fetchAssetAsText = async (url: string) => {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}: ${response.status}`);
+      }
+      return response.text();
+    };
+
+    const loadCustomAssets = async () => {
+      const cssUrl = `${unlayerAssetsBaseUrl}/customJs/main.css`;
+      const jsUrl = `${unlayerAssetsBaseUrl}/customJs/index.js`;
+
+      const maxAttempts = 20;
+      const delayMs = 1000;
+
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          const [cssText, jsText] = await Promise.all([
+            fetchAssetAsText(cssUrl),
+            fetchAssetAsText(jsUrl),
+          ]);
+
+          if (canceled) {
+            return;
+          }
+
+          setCustomCssSource(cssText);
+          setCustomJsSource(jsText);
+          return;
+        } catch (error) {
+          if (canceled) {
+            return;
+          }
+
+          if (attempt === maxAttempts) {
+            console.error(
+              'Could not load custom assets for inline injection',
+              error,
+            );
+            return;
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+      }
+    };
+
+    loadCustomAssets();
+
+    return () => {
+      canceled = true;
+    };
+  }, [shouldInlineCustomAssets, unlayerAssetsBaseUrl]);
   const projectId: number = parseInt(
     process.env.REACT_APP_PROJECT_ID as string,
     10,
@@ -46,6 +117,30 @@ const App: React.FC = () => {
     id: userId,
     signature: userSignature,
   } as User;
+  const customCss = shouldInlineCustomAssets
+    ? []
+    : [`${unlayerAssetsBaseUrl}/customJs/main.css`];
+
+  const customJsExtension =
+    shouldInlineCustomAssets && customCssSource && customJsSource
+      ? [
+          `(() => {
+            if (window.__dopplerCustomCssInjected) return;
+            const style = document.createElement("style");
+            style.setAttribute("data-doppler-custom-css", "true");
+            style.textContent = ${JSON.stringify(customCssSource)};
+            document.head.appendChild(style);
+            window.__dopplerCustomCssInjected = true;
+          })();`,
+          customJsSource,
+        ]
+      : shouldInlineCustomAssets
+        ? []
+        : [`${unlayerAssetsBaseUrl}/customJs/index.js`];
+  const inlineAssetsReady =
+    !shouldInlineCustomAssets ||
+    (customCssSource !== null && customJsSource !== null);
+
   const UnlayerOptionsExtended = {
     projectId,
     displayMode: 'email',
@@ -74,7 +169,7 @@ const App: React.FC = () => {
     },
     mergeTags,
     user: userExtend,
-    customCSS: [`${process.env.PUBLIC_URL}/customJs/main.css`],
+    customCSS: customCss,
     customJS: [
       `window["user-data"] = {
         fields : [
@@ -278,7 +373,7 @@ const App: React.FC = () => {
         integrations: "https://webappqa.fromdoppler.net/integrations"
         },
     };`,
-      `${process.env.PUBLIC_URL}/customJs/index.js`,
+      ...customJsExtension,
     ],
   } as UnlayerOptions;
 
@@ -302,11 +397,15 @@ const App: React.FC = () => {
         <button onClick={saveDesign}>Save Design</button>
         <button onClick={exportHtml}>Export HTML</button>
       </Bar>
-      <EmailEditor
-        key="email-editor-test"
-        ref={emailEditorRef}
-        options={UnlayerOptionsExtended}
-      />
+      {inlineAssetsReady ? (
+        <EmailEditor
+          key="email-editor-test"
+          ref={emailEditorRef}
+          options={UnlayerOptionsExtended}
+        />
+      ) : (
+        <p>Loading Unlayer custom assets...</p>
+      )}
     </div>
   );
 };

--- a/webpack-dev-server.config.js
+++ b/webpack-dev-server.config.js
@@ -16,6 +16,15 @@ module.exports = function (env) {
         devServer: {
             historyApiFallback: true,
             port: 3000,
+            host: '0.0.0.0',
+            allowedHosts: 'all',
+            headers: {
+                'Access-Control-Allow-Origin': 'https://editor.unlayer.com',
+                'Access-Control-Allow-Methods': 'GET, OPTIONS',
+                'Access-Control-Allow-Headers': '*',
+                'Access-Control-Allow-Private-Network': 'true',
+                'Cross-Origin-Resource-Policy': 'cross-origin',
+            },
             setupMiddlewares: (middlewares) => {
                 return middlewares.filter(middleware => middleware.name !== "cross-origin-header-check");
             }


### PR DESCRIPTION
**Descripción**
- cambia la carga de `customJs`/`main.css` para modo inline (evita bloqueo loopback/CORS desde `editor.unlayer.com`)
- inyecta CSS vía `customJS` (tag `<style>`) en vez de pasarlo por `customCSS` como URL
- agrega reintentos al cargar assets locales compilados (`public/customJs/*`)
- mantiene opción de desactivar inline con `REACT_APP_UNLAYER_INLINE_CUSTOM_ASSETS=false`
- simplifica docs y configuración local

Archivos incluidos:
- [App.tsx](/c:/Users/MS/proyectos/unlayer/src/App.tsx)
- [webpack-dev-server.config.js](/c:/Users/MS/proyectos/unlayer/webpack-dev-server.config.js)
- [README.md](/c:/Users/MS/proyectos/unlayer/README.md)
- [.env.development](/c:/Users/MS/proyectos/unlayer/.env.development)